### PR TITLE
use the correct msw logo

### DIFF
--- a/app/routes/_marketing+/index.tsx
+++ b/app/routes/_marketing+/index.tsx
@@ -69,7 +69,7 @@ export default function Index() {
 								href: 'https://playwright.dev/',
 							},
 							{
-								src: 'https://user-images.githubusercontent.com/1500684/157772386-75444196-0604-4340-af28-53b236faa182.svg',
+								src: 'https://raw.githubusercontent.com/mswjs/msw/c32241627da09af8b34c4068cc17dd1941ff3b0d/media/msw-logo.svg',
 								alt: 'MSW',
 								href: 'https://mswjs.io',
 							},


### PR DESCRIPTION
Hey! I caught a glimpse of the homepage of EpicStack and noticed that MSW logo wasn't right. That's on me, since we've put an incorrect logo on the website and forgot about (that's fixed as well, by the way). 

I'm replacing the logo to point to the SVG from the mswjs/msw repo. I don't know how to force it to load from `user-images.githubusercontent.com`, so feel free to correct the URL if you know how. 

Thanks for featuring MSW and can't wait to see what this stack grows into 👀 