### PR TITLE
fix: fix code to wrap a value with double quotation marks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-LITEFS_DIR=/litefs/data
+LITEFS_DIR="/litefs/data"
 DATABASE_PATH="./prisma/data.db"
 DATABASE_URL="file:./data.db?connection_limit=1"
 CACHE_DATABASE_PATH="./other/cache.db"


### PR DESCRIPTION
I noticed that the value for the LITEFS_DIR environment variable was not enclosed in double quotes. 
To maintain consistency and avoid any potential issues, I have updated the code to ensure the value is now wrapped in double quotes. 

Please review the changes.