### PR TITLE
fix litefs proxy db config

### DIFF
--- a/other/litefs.yml
+++ b/other/litefs.yml
@@ -12,7 +12,7 @@ proxy:
   # matches the internal_port in fly.toml
   addr: ':${INTERNAL_PORT}'
   target: 'localhost:${PORT}'
-  db: '${DATABASE_FILENAME}'
+  db: '${DATABASE_PATH}'
 
 # The lease section specifies how the cluster will be managed. We're using the
 # "consul" lease type so that our application can dynamically change the primary.


### PR DESCRIPTION
Hi,
I'm a new to the epic-stack!

I've been following your incredible tutorial at [tutorial](https://www.epicweb.dev/tutorials/deploy-web-applications) and noticed that the litefs proxy db configuration mentioned in the tutorial differs from the current configuration in the stack.

If my understanding is incorrect, please disregard this pull request.

Thank you for providing this awesome stack.
