### PR TITLE
Add missing extension to guiding-principles link

### DIFF
--- a/decisions/02-email-service.md
+++ b/decisions/02-email-service.md
@@ -17,7 +17,7 @@ game" of email deliverability, or you use a service that does. Otherwise, your
 emails won't reliably make it through spam filters (and in some cases it can
 just get deleted altogether).
 
-[The guiding principles](https://github.com/epicweb-dev/epic-stack/blob/main/docs/guiding-principles)
+[The guiding principles](https://github.com/epicweb-dev/epic-stack/blob/main/docs/guiding-principles.md)
 discourage services and encourage quick setup.
 
 ## Decision


### PR DESCRIPTION
this link was 404'ing in github, adding the extension fixes it.