### PR TITLE
Typescript'ified tailwind config and watching

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -8,6 +8,7 @@ module.exports = {
 	ignoredRouteFiles: ['**/*'],
 	serverModuleFormat: 'cjs',
 	postcss: true,
+	watchPaths: ['./tailwind.config.ts'],
 	future: {
 		v2_meta: true,
 		v2_errorBoundary: true,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
-const defaultTheme = require('tailwindcss/defaultTheme')
+import type { Config } from 'tailwindcss'
+import defaultTheme from 'tailwindcss/defaultTheme'
+import tailwindcssRadix from 'tailwindcss-radix'
 
-/** @type {import('tailwindcss').Config} */
 module.exports = {
 	content: ['./app/**/*.{ts,tsx,jsx,js}'],
 	darkMode: 'class',
@@ -75,5 +76,5 @@ module.exports = {
 			},
 		},
 	},
-	plugins: [require('tailwindcss-radix')],
-}
+	plugins: [tailwindcssRadix],
+} satisfies Config


### PR DESCRIPTION
As the title says, I have 

A) converted tailwind config to typescript and 
B) set up build-watch on it. In my experience this file is updated frequently (especially in the beginning of a project) and it makes sense to rebuild automatically on changes.

For B), one could argue that the file has content related to the app, so it should be located below app folder (app/styles/) which would enable automatic rebuild on change.
