### PR TITLE
fix: vitest afterAll fails on Windows

### DIFF
--- a/other/test-setup/setup-test-env.ts
+++ b/other/test-setup/setup-test-env.ts
@@ -7,6 +7,7 @@ import 'dotenv/config'
 import fs from 'fs'
 import { BASE_DATABASE_PATH, DATABASE_PATH } from './paths'
 import { deleteAllData } from './utils'
+import { prisma } from '~/utils/db.server'
 
 declare global {
 	namespace Vi {
@@ -24,5 +25,6 @@ fs.copyFileSync(BASE_DATABASE_PATH, DATABASE_PATH)
 afterEach(() => deleteAllData())
 
 afterAll(async () => {
+	await prisma.$disconnect()
 	await fs.promises.rm(DATABASE_PATH)
 })

--- a/other/test-setup/utils.ts
+++ b/other/test-setup/utils.ts
@@ -87,4 +87,6 @@ export function deleteAllData() {
 	for (const tableName of sortedTableNames) {
 		db.prepare(`DELETE FROM ${tableName}`).run()
 	}
+
+	db.close()
 }


### PR DESCRIPTION
resolve #53