### PR TITLE
Initial support for client hints

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -104,7 +104,7 @@ export default function App() {
 	return (
 		<html lang="en" className={`${theme} h-full`}>
 			<head>
-				<ClientHintCheck />
+				<ClientHintCheck nonce={nonce} />
 				<Meta />
 				<meta charSet="utf-8" />
 				<meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -24,6 +24,7 @@ import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import tailwindStylesheetUrl from './styles/tailwind.css'
 import { authenticator, getUserId } from './utils/auth.server.ts'
+import { ClientHintCheck } from './utils/client-hints.tsx'
 import { prisma } from './utils/db.server.ts'
 import { getEnv } from './utils/env.server.ts'
 import { ButtonLink } from './utils/forms.tsx'
@@ -91,6 +92,7 @@ export default function App() {
 	return (
 		<html lang="en" className="dark h-full">
 			<head>
+				<ClientHintCheck />
 				<Meta />
 				<meta charSet="utf-8" />
 				<meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/app/routes/resources+/theme.tsx
+++ b/app/routes/resources+/theme.tsx
@@ -1,0 +1,134 @@
+import { useForm } from '@conform-to/react'
+import { parse } from '@conform-to/zod'
+import { json, redirect, type DataFunctionArgs } from '@remix-run/node'
+import { useFetcher, useRevalidator } from '@remix-run/react'
+import * as React from 'react'
+import { z } from 'zod'
+import { colorSchemeHint } from '~/utils/client-hints.tsx'
+import { ErrorList } from '~/utils/forms.tsx'
+import { safeRedirect } from '~/utils/misc.ts'
+import { useRequestInfo } from '~/utils/request-info.ts'
+import {
+	commitSession,
+	deleteTheme,
+	getSession,
+	setTheme,
+} from '~/utils/session.server.ts'
+
+const ROUTE_PATH = '/resources/theme'
+
+const ThemeFormSchema = z.object({
+	redirectTo: z.string().optional(),
+	theme: z.enum(['system', 'light', 'dark']),
+})
+
+export async function action({ request }: DataFunctionArgs) {
+	const formData = await request.formData()
+	const submission = parse(formData, {
+		schema: ThemeFormSchema,
+		acceptMultipleErrors: () => true,
+	})
+	if (!submission.value) {
+		return json(
+			{
+				status: 'error',
+				submission,
+			} as const,
+			{ status: 400 },
+		)
+	}
+	if (submission.intent !== 'submit') {
+		return json({ status: 'success', submission } as const)
+	}
+	const session = await getSession(request.headers.get('cookie'))
+	const { redirectTo, theme } = submission.value
+	if (theme === 'system') {
+		deleteTheme(session)
+	} else {
+		setTheme(session, theme)
+	}
+
+	const responseInit = {
+		headers: { 'Set-Cookie': await commitSession(session) },
+	}
+	if (redirectTo) {
+		return redirect(safeRedirect(redirectTo), responseInit)
+	} else {
+		return json({ success: true }, responseInit)
+	}
+}
+
+export function ThemeSwitch({
+	userPreference,
+}: {
+	userPreference: 'light' | 'dark' | null
+}) {
+	const requestInfo = useRequestInfo()
+	const fetcher = useFetcher()
+	const [isHydrated, setIsHydrated] = React.useState(false)
+	const { revalidate } = useRevalidator()
+
+	React.useEffect(() => {
+		setIsHydrated(true)
+	}, [])
+
+	React.useEffect(() => {
+		const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+		const handleChange = () => {
+			document.cookie = `${colorSchemeHint.cookieName}=${
+				mediaQuery.matches ? 'dark' : 'light'
+			}`
+			revalidate()
+		}
+		mediaQuery.addEventListener('change', handleChange)
+		return () => mediaQuery.removeEventListener('change', handleChange)
+	}, [revalidate])
+
+	const [form] = useForm({
+		id: 'onboarding',
+		lastSubmission: fetcher.data?.submission,
+		onValidate({ formData }) {
+			return parse(formData, { schema: ThemeFormSchema })
+		},
+	})
+
+	const mode = userPreference ?? 'system'
+	const nextMode =
+		mode === 'system' ? 'light' : mode === 'light' ? 'dark' : 'system'
+	const modeLabel = {
+		light: (
+			<>
+				🔆 <span className="sr-only">Light</span>
+			</>
+		),
+		dark: (
+			<>
+				🌕 <span className="sr-only">Dark</span>
+			</>
+		),
+		system: (
+			<>
+				💻 <span className="sr-only">System</span>
+			</>
+		),
+	}
+
+	return (
+		<fetcher.Form method="POST" action={ROUTE_PATH} {...form.props}>
+			<div className="flex gap-2">
+				{/*
+					this is for progressive enhancement so we redirect them to the page
+					they are on if the JavaScript hasn't had a chance to hydrate yet.
+				*/}
+				{isHydrated ? null : (
+					<input type="hidden" name="redirectTo" value={requestInfo.path} />
+				)}
+				<input type="hidden" name="theme" value={nextMode} />
+				<button className="flex h-8 w-8 cursor-pointer items-center justify-center">
+					{modeLabel[mode]}
+				</button>
+			</div>
+			<ErrorList errors={form.errors} id={form.errorId} />
+		</fetcher.Form>
+	)
+}

--- a/app/utils/client-hints.tsx
+++ b/app/utils/client-hints.tsx
@@ -66,9 +66,10 @@ export function getHints(request?: Request) {
  * if they are not set then reloads the page if any cookie was set to an
  * inaccurate value.
  */
-export function ClientHintCheck() {
+export function ClientHintCheck({ nonce }: { nonce: string }) {
 	return (
 		<script
+			nonce={nonce}
 			dangerouslySetInnerHTML={{
 				__html: `
 const cookies = document.cookie.split(';').map(c => c.trim()).reduce((acc, cur) => {

--- a/app/utils/client-hints.tsx
+++ b/app/utils/client-hints.tsx
@@ -1,0 +1,107 @@
+import { type Request } from '@remix-run/node'
+
+const colorSchemeHint = {
+	name: 'CH-prefers-color-scheme',
+	getValueCode: `window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'`,
+	fallback: 'light',
+	transform(value: any) {
+		return value === 'dark' ? 'dark' : 'light'
+	},
+} as const
+
+const clockOffsetHint = {
+	name: 'CH-clock-offset',
+	getValueCode: `new Date().getTimezoneOffset() * -1`,
+	fallback: '0',
+	transform(value: any) {
+		return !isNaN(Number(value)) ? Number(value) : 0
+	},
+} as const
+
+const clientHints = [colorSchemeHint, clockOffsetHint] as const
+
+type ClientHintNames = (typeof clientHints)[number]['name']
+
+function getCookieValue(cookieString: string, name: ClientHintNames) {
+	const hint = clientHints.find(hint => hint.name === name)
+	if (!hint) {
+		throw new Error(`Unknown client hint: ${name}`)
+	}
+	const value = cookieString
+		.split(';')
+		.map(c => c.trim())
+		.find(c => c.startsWith(name + '='))
+		?.split('=')[1]
+
+	return value ?? null
+}
+
+function getCookieString(request?: Request) {
+	return typeof document !== 'undefined'
+		? document.cookie
+		: typeof request !== 'undefined'
+		? request.headers.get('Cookie') ?? ''
+		: ''
+}
+
+/**
+ *
+ * @param request {Request} - optional request object (only used on server)
+ * @returns the theme value of "light" or "dark"
+ */
+export function getThemeHint(request?: Request) {
+	const cookieString = getCookieString(request)
+	return colorSchemeHint.transform(
+		getCookieValue(cookieString, colorSchemeHint.name),
+	)
+}
+
+/**
+ * @param request {Request} - optional request object (only used on server)
+ * @returns the clock offset value in minutes
+ */
+export function getClockOffsetHint(request?: Request) {
+	const cookieString = getCookieString(request)
+	return clockOffsetHint.transform(
+		getCookieValue(cookieString, clockOffsetHint.name),
+	)
+}
+
+/**
+ * @returns inline script element that checks for client hints and sets cookies
+ * if they are not set then reloads the page if any cookie was set to an
+ * inaccurate value.
+ */
+export function ClientHintCheck() {
+	return (
+		<script
+			dangerouslySetInnerHTML={{
+				__html: `
+const cookies = document.cookie.split(';').map(c => c.trim()).reduce((acc, cur) => {
+	const [key, value] = cur.split('=');
+	acc[key] = value;
+	return acc;
+}, {});
+let cookieChanged = false;
+const hints = [
+${clientHints
+	.map(hint => {
+		const name = JSON.stringify(hint.name)
+		return `{ name: ${name}, actual: String(${hint.getValueCode}), cookie: cookies[${name}] }`
+	})
+	.join(',\n')}
+];
+for (const hint of hints) {
+	if (hint.cookie !== hint.actual) {
+		cookieChanged = true;
+		document.cookie = hint.name + '=' + hint.actual;
+	}
+}
+if (cookieChanged) {
+	window.location.reload();
+}
+			`,
+			}}
+		/>
+	)
+}

--- a/app/utils/request-info.ts
+++ b/app/utils/request-info.ts
@@ -1,0 +1,8 @@
+import { type SerializeFrom } from '@remix-run/node'
+import { useRouteLoaderData } from '@remix-run/react'
+import { type loader as rootLoader } from '~/root.tsx'
+
+export function useRequestInfo() {
+	const data = useRouteLoaderData('root') as SerializeFrom<typeof rootLoader>
+	return data.requestInfo
+}

--- a/app/utils/session.server.ts
+++ b/app/utils/session.server.ts
@@ -1,7 +1,4 @@
 import { createCookieSessionStorage } from '@remix-run/node'
-import invariant from 'tiny-invariant'
-
-invariant(process.env.SESSION_SECRET, 'SESSION_SECRET must be set')
 
 export const sessionStorage = createCookieSessionStorage({
 	cookie: {
@@ -14,5 +11,22 @@ export const sessionStorage = createCookieSessionStorage({
 	},
 })
 
-// you can also export the methods individually for your own usage
 export const { getSession, commitSession, destroySession } = sessionStorage
+
+type Session = Awaited<ReturnType<typeof getSession>>
+
+const themeKey = 'theme'
+
+export function getTheme(session: Session): 'dark' | 'light' | null {
+	const theme = session.get(themeKey)
+	if (theme === 'dark' || theme === 'light') return theme
+	return null
+}
+
+export function setTheme(session: Session, theme: 'dark' | 'light') {
+	session.set(themeKey, theme)
+}
+
+export function deleteTheme(session: Session) {
+	session.unset(themeKey)
+}

--- a/docs/client-hints.md
+++ b/docs/client-hints.md
@@ -1,0 +1,54 @@
+# Client Hints
+
+> **NOTE:** Find background on this concept in the decision document:
+> `05-client-pref-cookies.md`.
+
+## The Problem
+
+Sometimes your server render code needs to know something about the client that
+the browser doesn't send. For example, the server might need to know the user's
+preferred language, or whether the user prefers light or dark mode.
+
+For some of this you should have user preferences which can be persisted in a
+cookie or a database, but you can't do this for first-time visitors. All you can
+do is guess. Unfortunately, if you guess wrong, you end up with a bad experience
+for the user.
+
+And what often happens is we render HTML that's wrong and then hydrate the
+application to be interactive with client-side JavaScript that now knows the
+user preferences and now we know the right thing to render. This is great,
+except we've already render the wrong thing so by hydrating we cause a shift
+from the wrong thing to the right thing which is jarring and can be even a worse
+user experience than leaving the wrong thing in place (I call this a "flash of
+incorrect content"). You'll get an error in the console from React when this
+happens.
+
+## The Solution
+
+Client hints are a way to avoid this problem. The standards for this are still a
+work in progress and there is uncertainty when they will land in all major
+browsers we are concerned with supporting. So the Epic Stack comes with built-in
+support for a "ponyfill" of sorts of a similar feature to the client hints
+headers proposed to the standard.
+
+The idea behind the standard is when the browser makes a request, instead of
+responding to the request immediately, the server instead responds to the client
+informing it there's a need for for certain headers. The client will then repeat
+the request with those headers added. The server can then respond with the
+correct content.
+
+Our solution is inspired by this, but instead of headers we use cookies. In
+`app/utils/client-hints.tsx` we have a component called `ClientHintCheck` which
+is rendered in the `<head>` of our document before anything else. That component
+renders a small and fast inline script which checks the user's cookies for the
+expected client hints. If they are not present or if they're outdated, it sets a
+cookie and triggers a reload of the page. Effectively doing the same thing the
+browser would do with the client hints headers.
+
+This allows us to server render the right thing for first time visitors without
+triggering a content layout shift or a flash of incorrect content. After that
+first render, the client will have the correct cookies and the server will
+render the right thing every time thereafter.
+
+The built-in template currently only has support for the user's color scheme
+preference, but you can add more for your application's needs.


### PR DESCRIPTION
This implements the ideas described in https://github.com/epicweb-dev/epic-stack/blob/main/decisions/05-client-pref-cookies.md

Eventually we'll want locale stuff in here as well I expect. For now, the timezone offset and theme preference are necessary. I would love ideas and suggestions here. I'm going to be adding full theme support (via user preference) based on this before we merge this. In that world, the client hint for the desired theme is only used when the user chooses "system".