### PR TITLE
fix typo

### DIFF
--- a/decisions/01-typescript-only.md
+++ b/decisions/01-typescript-only.md
@@ -7,7 +7,7 @@ Status: accepted
 ## Context
 
 The `create-remix` CLI allows users to select whether they want to use
-TypeScript instead of JavaScript. This will auto-convert everything to
+JavaScript instead of TypeScript. This will auto-convert everything to
 TypeScript.
 
 There is (currently) no way to control this behavior.

--- a/decisions/01-typescript-only.md
+++ b/decisions/01-typescript-only.md
@@ -8,7 +8,7 @@ Status: accepted
 
 The `create-remix` CLI allows users to select whether they want to use
 TypeScript instead of JavaScript. This will auto-convert everything to
-JavaScript.
+TypeScript.
 
 There is (currently) no way to control this behavior.
 

--- a/decisions/01-typescript-only.md
+++ b/decisions/01-typescript-only.md
@@ -8,7 +8,7 @@ Status: accepted
 
 The `create-remix` CLI allows users to select whether they want to use
 JavaScript instead of TypeScript. This will auto-convert everything to
-TypeScript.
+JavaScript.
 
 There is (currently) no way to control this behavior.
 


### PR DESCRIPTION
Fix typo.

Selecting the TypeScript option will auto-convert everything to *TypeScript*