### PR TITLE
fix: pass only relavent props to each field

### DIFF
--- a/app/routes/_auth+/forgot-password.tsx
+++ b/app/routes/_auth+/forgot-password.tsx
@@ -1,4 +1,4 @@
-import { useForm } from '@conform-to/react'
+import { conform, useForm } from '@conform-to/react'
 import { getFieldsetConstraint, parse } from '@conform-to/zod'
 import {
 	json,
@@ -169,7 +169,7 @@ export default function SignupRoute() {
 										htmlFor: fields.usernameOrEmail.id,
 										children: 'Username or Email',
 									}}
-									inputProps={fields.usernameOrEmail}
+									inputProps={conform.input(fields.usernameOrEmail)}
 									errors={fields.usernameOrEmail.errors}
 								/>
 							</div>

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -1,4 +1,4 @@
-import { useForm } from '@conform-to/react'
+import { conform, useForm } from '@conform-to/react'
 import { getFieldsetConstraint, parse } from '@conform-to/zod'
 import {
 	json,
@@ -160,27 +160,25 @@ export default function OnboardingPage() {
 					<Field
 						labelProps={{ htmlFor: fields.username.id, children: 'Username' }}
 						inputProps={{
-							...fields.username,
+							...conform.input(fields.username),
 							autoComplete: 'username',
-							autoFocus: true,
+							autoFocus: typeof actionData === 'undefined' || typeof fields.username.initialError !== 'undefined',
 						}}
 						errors={fields.username.errors}
 					/>
 					<Field
 						labelProps={{ htmlFor: fields.name.id, children: 'Name' }}
 						inputProps={{
-							...fields.name,
+							...conform.input(fields.name),
 							autoComplete: 'name',
-							autoFocus: true,
 						}}
 						errors={fields.name.errors}
 					/>
 					<Field
 						labelProps={{ htmlFor: fields.password.id, children: 'Password' }}
 						inputProps={{
-							...fields.password,
+							...conform.input(fields.password, { type: 'password' }),
 							autoComplete: 'new-password',
-							type: 'password',
 						}}
 						errors={fields.password.errors}
 					/>
@@ -191,9 +189,8 @@ export default function OnboardingPage() {
 							children: 'Confirm Password',
 						}}
 						inputProps={{
-							...fields.confirmPassword,
+							...conform.input(fields.confirmPassword, { type: 'password' }),
 							autoComplete: 'new-password',
-							type: 'password',
 						}}
 						errors={fields.confirmPassword.errors}
 					/>
@@ -204,7 +201,7 @@ export default function OnboardingPage() {
 							children:
 								'Do you agree to our Terms of Service and Privacy Policy?',
 						}}
-						buttonProps={fields.agreeToTermsOfServiceAndPrivacyPolicy}
+						buttonProps={conform.input(fields.agreeToTermsOfServiceAndPrivacyPolicy, { type: 'checkbox' })}
 						errors={fields.agreeToTermsOfServiceAndPrivacyPolicy.errors}
 					/>
 
@@ -214,7 +211,7 @@ export default function OnboardingPage() {
 							children:
 								'Would you like to receive special discounts and offers?',
 						}}
-						buttonProps={fields.agreeToMailingList}
+						buttonProps={conform.input(fields.agreeToMailingList, { type: 'checkbox' })}
 						errors={fields.agreeToMailingList.errors}
 					/>
 
@@ -223,11 +220,11 @@ export default function OnboardingPage() {
 							htmlFor: fields.remember.id,
 							children: 'Remember me',
 						}}
-						buttonProps={fields.remember}
+						buttonProps={conform.input(fields.remember, { type: 'checkbox' })}
 						errors={fields.remember.errors}
 					/>
 
-					<input {...fields.redirectTo} type="hidden" value={redirectTo} />
+					<input name={fields.redirectTo.name} type="hidden" value={redirectTo} />
 
 					<ErrorList errors={data.formError ? [data.formError] : []} />
 					<ErrorList errors={form.errors} id={form.errorId} />

--- a/app/routes/_auth+/reset-password.tsx
+++ b/app/routes/_auth+/reset-password.tsx
@@ -15,7 +15,7 @@ import { z } from 'zod'
 import { GeneralErrorBoundary } from '~/components/error-boundary.tsx'
 import { authenticator, resetUserPassword } from '~/utils/auth.server.ts'
 import { Button, ErrorList, Field } from '~/utils/forms.tsx'
-import { useForm } from '@conform-to/react'
+import { conform, useForm } from '@conform-to/react'
 import { getFieldsetConstraint, parse } from '@conform-to/zod'
 import { commitSession, getSession } from '~/utils/session.server.ts'
 import { passwordSchema } from '~/utils/user-validation.ts'
@@ -120,8 +120,7 @@ export default function ResetPasswordPage() {
 						children: 'New Password',
 					}}
 					inputProps={{
-						...fields.password,
-						type: 'password',
+						...conform.input(fields.password, { type: 'password' }),
 						autoComplete: 'new-password',
 					}}
 					errors={fields.password.errors}
@@ -132,8 +131,7 @@ export default function ResetPasswordPage() {
 						children: 'Confirm Password',
 					}}
 					inputProps={{
-						...fields.confirmPassword,
-						type: 'password',
+						...conform.input(fields.confirmPassword, { type: 'password' }),
 						autoComplete: 'new-password',
 					}}
 					errors={fields.confirmPassword.errors}

--- a/app/routes/resources+/login.tsx
+++ b/app/routes/resources+/login.tsx
@@ -1,4 +1,4 @@
-import { useForm } from '@conform-to/react'
+import { conform, useForm } from '@conform-to/react'
 import { getFieldsetConstraint, parse } from '@conform-to/zod'
 import { json, redirect, type DataFunctionArgs } from '@remix-run/node'
 import { Link, useFetcher } from '@remix-run/react'
@@ -110,7 +110,7 @@ export function InlineLogin({
 							htmlFor: fields.username.id,
 							children: 'Username',
 						}}
-						inputProps={fields.username}
+						inputProps={conform.input(fields.username)}
 						errors={fields.username.errors}
 					/>
 
@@ -119,7 +119,7 @@ export function InlineLogin({
 							htmlFor: fields.password.id,
 							children: 'Password',
 						}}
-						inputProps={{ ...fields.password, type: 'password' }}
+						inputProps={conform.input(fields.password, { type: 'password' })}
 						errors={fields.password.errors}
 					/>
 
@@ -129,7 +129,7 @@ export function InlineLogin({
 								htmlFor: fields.remember.id,
 								children: 'Remember me',
 							}}
-							buttonProps={fields.remember}
+							buttonProps={conform.input(fields.remember, { type: 'checkbox' })}
 							errors={fields.remember.errors}
 						/>
 

--- a/app/routes/resources+/note-editor.tsx
+++ b/app/routes/resources+/note-editor.tsx
@@ -1,4 +1,4 @@
-import { useForm } from '@conform-to/react'
+import { conform, useForm } from '@conform-to/react'
 import { getFieldsetConstraint, parse } from '@conform-to/zod'
 import { json, redirect, type DataFunctionArgs } from '@remix-run/node'
 import { useFetcher } from '@remix-run/react'
@@ -89,6 +89,10 @@ export function NoteEditor({
 		onValidate({ formData }) {
 			return parse(formData, { schema: NoteEditorSchema })
 		},
+		defaultValue: {
+			title: note?.title,
+			content: note?.content,
+		},
 		shouldRevalidate: 'onBlur',
 	})
 
@@ -102,18 +106,16 @@ export function NoteEditor({
 			<Field
 				labelProps={{ htmlFor: fields.title.id, children: 'Title' }}
 				inputProps={{
-					...fields.title,
+					...conform.input(fields.title),
 					autoComplete: 'title',
-					defaultValue: note?.title,
 				}}
 				errors={fields.title.errors}
 			/>
 			<TextareaField
 				labelProps={{ htmlFor: fields.content.id, children: 'Content' }}
 				textareaProps={{
-					...fields.content,
+					...conform.textarea(fields.content),
 					autoComplete: 'content',
-					defaultValue: note?.content,
 				}}
 				errors={fields.content.errors}
 			/>

--- a/app/routes/settings+/profile.tsx
+++ b/app/routes/settings+/profile.tsx
@@ -1,4 +1,4 @@
-import { useForm } from '@conform-to/react'
+import { conform, useForm } from '@conform-to/react'
 import { getFieldsetConstraint, parse } from '@conform-to/zod'
 import { json, redirect, type DataFunctionArgs } from '@remix-run/node'
 import {
@@ -146,6 +146,10 @@ export default function EditUserProfile() {
 		onValidate({ formData }) {
 			return parse(formData, { schema: ProfileFormSchema })
 		},
+		defaultValue: {
+			name: data.user.name ?? '',
+			email: data.user.email,
+		},
 		shouldRevalidate: 'onBlur',
 	})
 
@@ -193,18 +197,14 @@ export default function EditUserProfile() {
 						<Field
 							className="col-span-3"
 							labelProps={{ htmlFor: fields.name.id, children: 'Name' }}
-							inputProps={{
-								...fields.name,
-								defaultValue: data.user.name ?? '',
-							}}
+							inputProps={conform.input(fields.name)}
 							errors={fields.name.errors}
 						/>
 						<Field
 							className="col-span-3"
 							labelProps={{ htmlFor: fields.email.id, children: 'Email' }}
 							inputProps={{
-								...fields.email,
-								defaultValue: data.user.email ?? '',
+								...conform.input(fields.email),
 								// TODO: support changing your email address
 								disabled: true,
 							}}
@@ -224,8 +224,7 @@ export default function EditUserProfile() {
 										children: 'Current Password',
 									}}
 									inputProps={{
-										...fields.currentPassword,
-										type: 'password',
+										...conform.input(fields.currentPassword, { type: 'password' }),
 										autoComplete: 'current-password',
 									}}
 									errors={fields.currentPassword.errors}
@@ -237,8 +236,7 @@ export default function EditUserProfile() {
 										children: 'New Password',
 									}}
 									inputProps={{
-										...fields.newPassword,
-										type: 'password',
+										...conform.input(fields.newPassword, { type: 'password' }),
 										autoComplete: 'new-password',
 									}}
 									errors={fields.newPassword.errors}


### PR DESCRIPTION
Looks like we were passing the field props directly to the field component which end up setting extra props like `initialError`, `errorId` or `descriptionId` on the element as well. 

```html
<input id="edit-profile-name" placeholder=" " name="name" initialerror="[object Object]" form="edit-profile" errorid="edit-profile-name-error" descriptionid="edit-profile-name-description" class="h-14 w-full rounded-lg border border-night-400 bg-night-700 px-4 pt-4 text-body-xs caret-white outline-none focus:border-accent-purple disabled:bg-night-400" value="Kody">
```

This PR restrict what we are passing by using the [conform](https://conform.guide/api/react#conform) helper.