### PR TITLE
Set default region for both machines and volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Prior to your first deployment, you'll need to do a few things:
   make sure you change the `primary_region` in fly.toml as well):
 
   ```sh
-  fly volumes create data --region sjc --size 1  --app epic-stack-template
+  fly volumes create data --region sjc --size 1 --app epic-stack-template
   fly volumes create data --region sjc --size 1 --app epic-stack-template-staging
   ```
 

--- a/README.md
+++ b/README.md
@@ -199,11 +199,13 @@ Prior to your first deployment, you'll need to do a few things:
 
 - Create a persistent volume for the sqlite database for both your staging and
   production environments. Run the following (feel free to change the GB size
-  based on your needs):
+  based on your needs and the region of your choice
+  (`https://fly.io/docs/reference/regions/`). NB. If you do change the region,
+  make sure you change the `primary_region` in fly.toml as well):
 
   ```sh
-  fly volumes create data --size 1 --app epic-stack-template
-  fly volumes create data --size 1 --app epic-stack-template-staging
+  fly volumes create data --region sjc --size 1  --app epic-stack-template
+  fly volumes create data --region sjc --size 1 --app epic-stack-template-staging
   ```
 
 Now that everything is set up you can commit and push your changes to your repo.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Prior to your first deployment, you'll need to do a few things:
 - Create a persistent volume for the sqlite database for both your staging and
   production environments. Run the following (feel free to change the GB size
   based on your needs and the region of your choice
-  (`https://fly.io/docs/reference/regions/`). NB. If you do change the region,
+  (`https://fly.io/docs/reference/regions/`). If you do change the region,
   make sure you change the `primary_region` in fly.toml as well):
 
   ```sh

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,5 @@
 app = "epic-stack-template"
+primary_region = "sjc"
 kill_signal = "SIGINT"
 kill_timeout = 5
 processes = [ ]


### PR DESCRIPTION
It seems like for some fly users (me and also reported by @joshmedeski here: https://github.com/epicweb-dev/epic-stack/issues/68), that the default region for machines and volumes are not the same and a deploy will fail because machine and mounted volume needs to be in same region. Specifying them explicitly solves the problem. I picked "sjc" a bit randomly, it could just as well be another, but it will never fit all users anyway.

Documentation for "primary_region": https://fly.io/docs/reference/configuration/#primary-region