### PR TITLE
Automatically install Playwright browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prisma:studio": "prisma studio",
     "format": "prettier --write .",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
-    "setup": "prisma generate && prisma migrate deploy && prisma db seed",
+    "setup": "prisma generate && prisma migrate deploy && prisma db seed && playwright install",
     "start": "cross-env NODE_ENV=production node .",
     "start:mocks": "cross-env NODE_ENV=production MOCKS=true tsx .",
     "test": "vitest",


### PR DESCRIPTION
Fixes #94

Install Playwright browsers on setup

## Test Plan

1. Run with local template: `npx create-remix@latest --typescript --install --template ./epic-stack`
2. Check the Playwright browsers where installed ✅

## Checklist

Do we need some tests/docs for this?

## Screenshots

N/A