### PR TITLE
Refine conform setup

### DIFF
--- a/app/routes/_auth+/forgot-password.tsx
+++ b/app/routes/_auth+/forgot-password.tsx
@@ -61,6 +61,9 @@ export async function action({ request }: DataFunctionArgs) {
 		schema: forgotPasswordSchema,
 		acceptMultipleErrors: () => true,
 	})
+	if (submission.intent !== 'submit') {
+		return json({ status: 'idle', submission } as const)
+	}
 	if (!submission.value) {
 		return json(
 			{
@@ -69,9 +72,6 @@ export async function action({ request }: DataFunctionArgs) {
 			} as const,
 			{ status: 400 },
 		)
-	}
-	if (submission.intent !== 'submit') {
-		return json({ status: 'success', submission } as const)
 	}
 	const { usernameOrEmail } = submission.value
 

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -81,6 +81,9 @@ export async function action({ request }: DataFunctionArgs) {
 		schema: OnboardingFormSchema,
 		acceptMultipleErrors: () => true,
 	})
+	if (submission.intent !== 'submit') {
+		return json({ status: 'idle', submission } as const)
+	}
 	if (!submission.value) {
 		return json(
 			{
@@ -89,9 +92,6 @@ export async function action({ request }: DataFunctionArgs) {
 			} as const,
 			{ status: 400 },
 		)
-	}
-	if (submission.intent !== 'submit') {
-		return json({ status: 'success', submission } as const)
 	}
 	const {
 		username,

--- a/app/routes/_auth+/reset-password.tsx
+++ b/app/routes/_auth+/reset-password.tsx
@@ -60,7 +60,10 @@ export async function action({ request }: DataFunctionArgs) {
 		schema: ResetPasswordSchema,
 		acceptMultipleErrors: () => true,
 	})
-	if (!submission.value || submission.intent !== 'submit') {
+	if (submission.intent !== 'submit') {
+		return json({ status: 'idle', submission } as const);
+	}
+	if (!submission.value) {
 		return json(
 			{
 				status: 'error',

--- a/app/routes/_auth+/signup.tsx
+++ b/app/routes/_auth+/signup.tsx
@@ -96,7 +96,10 @@ export async function action({ request }: DataFunctionArgs) {
 		acceptMultipleErrors: () => true,
 		async: true,
 	})
-	if (!submission.value || submission.intent !== 'submit') {
+	if (submission.intent !== 'submit') {
+		return json({ status: 'idle', submission } as const)
+	}
+	if (!submission.value) {
 		return json(
 			{
 				status: 'error',

--- a/app/routes/_auth+/signup.tsx
+++ b/app/routes/_auth+/signup.tsx
@@ -23,10 +23,8 @@ const tokenType = 'onboarding'
 
 function createSchema(
 	constraints: {
-		isEmailUnique: (email: string) => Promise<boolean>
-	} = {
-		isEmailUnique: async () => true,
-	},
+		isEmailUnique?: (email: string) => Promise<boolean>
+	} = {},
 ) {
 	const signupSchema = z.object({
 		email: emailSchema.superRefine((email, ctx) => {
@@ -36,6 +34,7 @@ function createSchema(
 					code: z.ZodIssueCode.custom,
 					message: conform.VALIDATION_UNDEFINED,
 				})
+				return;
 			}
 			// if constraint is defined, validate uniqueness
 			return constraints.isEmailUnique(email).then(isUnique => {

--- a/app/routes/resources+/note-editor.tsx
+++ b/app/routes/resources+/note-editor.tsx
@@ -20,6 +20,9 @@ export async function action({ request }: DataFunctionArgs) {
 		schema: NoteEditorSchema,
 		acceptMultipleErrors: () => true,
 	})
+	if (submission.intent !== 'submit') {
+		return json({ status: 'idle', submission } as const)
+	}
 	if (!submission.value) {
 		return json(
 			{
@@ -28,9 +31,6 @@ export async function action({ request }: DataFunctionArgs) {
 			} as const,
 			{ status: 400 },
 		)
-	}
-	if (submission.intent !== 'submit') {
-		return json({ status: 'success', submission } as const)
 	}
 	let note: { id: string; owner: { username: string } }
 

--- a/app/routes/settings+/profile.photo.tsx
+++ b/app/routes/settings+/profile.photo.tsx
@@ -64,7 +64,10 @@ export async function action({ request }: DataFunctionArgs) {
 
 	const submission = parse(formData, { schema: PhotoFormSchema })
 
-	if (!submission.value || submission.intent !== 'submit') {
+	if (submission.intent !== 'submit') {
+		return json({ status: 'idle', submission } as const)
+	}
+	if (!submission.value) {
 		return json(
 			{
 				status: 'error',

--- a/app/routes/settings+/profile.tsx
+++ b/app/routes/settings+/profile.tsx
@@ -91,6 +91,9 @@ export async function action({ request }: DataFunctionArgs) {
 		),
 		acceptMultipleErrors: () => true,
 	})
+	if (submission.intent !== 'submit') {
+		return json({ status: 'idle', submission } as const)
+	}
 	if (!submission.value) {
 		return json(
 			{
@@ -99,9 +102,6 @@ export async function action({ request }: DataFunctionArgs) {
 			} as const,
 			{ status: 400 },
 		)
-	}
-	if (submission.intent !== 'submit') {
-		return json({ status: 'success', submission } as const)
 	}
 	const { name, username, email, newPassword } = submission.value
 


### PR DESCRIPTION
This fixes the async validation setup on the signup form as mentioned on #102 with an improvement on how submission intent is handled:

As Conform is using the action for async validation as well, the status on the action data was interpreted as an error and triggered a red cross to be displayed on the submit button before the user actually submit the form. It's now returning the submission with an idle status instead until an actual submission is made.

## Test Plan

- Go to `/signup`
- Fill in `kody@kcd.dev` on the email
- An error should be shown once the field is unfocused
- Typing another email
- The error should be gone once the field is unfocused again

## Checklist

- [ ] Tests updated
- [ ] Docs updated