### PR TITLE
refine username validation to not be able to use an email as username

### DIFF
--- a/app/utils/user-validation.ts
+++ b/app/utils/user-validation.ts
@@ -4,7 +4,7 @@ export const usernameSchema = z
 	.string()
 	.min(3, { message: 'Username is too short' })
 	.max(20, { message: 'Username is too long' })
-	.regex(/^[^@]*$/, "username can not contains @")
+	.regex(/^[^@]*$/, 'Username can not contain @')
 export const passwordSchema = z
 	.string()
 	.min(6, { message: 'Password is too short' })

--- a/app/utils/user-validation.ts
+++ b/app/utils/user-validation.ts
@@ -4,6 +4,7 @@ export const usernameSchema = z
 	.string()
 	.min(3, { message: 'Username is too short' })
 	.max(20, { message: 'Username is too long' })
+	.regex(new RegExp("^[^@]*$"), "username can not contains @")
 export const passwordSchema = z
 	.string()
 	.min(6, { message: 'Password is too short' })

--- a/app/utils/user-validation.ts
+++ b/app/utils/user-validation.ts
@@ -4,7 +4,7 @@ export const usernameSchema = z
 	.string()
 	.min(3, { message: 'Username is too short' })
 	.max(20, { message: 'Username is too long' })
-	.regex(new RegExp("^[^@]*$"), "username can not contains @")
+	.regex(/^[^@]*$/, "username can not contains @")
 export const passwordSchema = z
 	.string()
 	.min(6, { message: 'Password is too short' })

--- a/app/utils/user-validation.ts
+++ b/app/utils/user-validation.ts
@@ -4,7 +4,7 @@ export const usernameSchema = z
 	.string()
 	.min(3, { message: 'Username is too short' })
 	.max(20, { message: 'Username is too long' })
-	.regex(/^[^@]*$/, 'Username can not contain @')
+	.regex(/^[^@]*$/, 'Username can not contain "@"')
 export const passwordSchema = z
 	.string()
 	.min(6, { message: 'Password is too short' })


### PR DESCRIPTION
An user can use an email as usernam. This can conflict when using method that takes an argument as username or password and find the user for any of them. 

## Test Plan

I have verify locally that the regex is OK using an username with `@` gives a zod error and if the username does not contain `@` it works as expected.
