### PR TITLE
Fix link to the decision file

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -4,7 +4,7 @@ Epic Stack apps start with a single instance with 256MB of memory. This is a
 pretty small amount of memory, but it's enough to get started with. To help
 avoid memory pressure even at that scale, we allocate a 512MB swap file. Learn
 more about this decision in
-[the memory swap decision document](decisions/007-swap-file.md).
+[the memory swap decision document](decisions/010-memory-swap.md).
 
 To modify or increase the swap file, check `other/setup-swap.js`. This file is
 executed before running our app within the `litefs.yml` config.


### PR DESCRIPTION
It's just a quick fix of link to the related markdown file

## Test Plan

---

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

Before: 
<img width="1232" alt="image" src="https://github.com/epicweb-dev/epic-stack/assets/54995479/9d31e98b-0ba1-4233-8cce-18bac5cfd716">


