### PR TITLE
Add font metric overrides to reduce CLS induced by font swap

### DIFF
--- a/public/fonts/nunito-sans/font.css
+++ b/public/fonts/nunito-sans/font.css
@@ -166,3 +166,151 @@
 			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-900italic.woff')
 			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
+/* Font metric overrides reduces CLS from font-swap.
+This is manually inserted, metric generated using CLI commands:
+npx fontpie ./public/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-200.woff2 -weight 200 -style normal 
+npx fontpie ./public/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-300italic.woff2 -weight 300 -style italic 
+etc...
+*/
+@font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: normal;
+	font-weight: 200;
+	src: local('Arial');
+	ascent-override: 103.02%;
+	descent-override: 35.97%;
+	line-gap-override: 0.00%;
+	size-adjust: 98.13%;
+  }
+  @font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: italic;
+	font-weight: 200;
+	src: local('Arial Italic');
+	ascent-override: 103.02%;
+	descent-override: 35.97%;
+	line-gap-override: 0.00%;
+	size-adjust: 98.13%;
+  }
+  @font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: normal;
+	font-weight: 300;
+	src: local('Arial');
+	ascent-override: 101.29%;
+	descent-override: 35.37%;
+	line-gap-override: 0.00%;
+	size-adjust: 99.82%;
+  }
+  @font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: italic;
+	font-weight: 300;
+	src: local('Arial Italic');
+	ascent-override: 101.27%;
+	descent-override: 35.36%;
+	line-gap-override: 0.00%;
+	size-adjust: 99.84%;
+  }  
+  @font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: normal;
+	font-weight: 400;
+	src: local('Arial');
+	ascent-override: 99.49%;
+	descent-override: 34.74%;
+	line-gap-override: 0.00%;
+	size-adjust: 101.62%;
+  }
+  @font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: italic;
+	font-weight: 400;
+	src: local('Arial Italic');
+	ascent-override: 99.49%;
+	descent-override: 34.74%;
+	line-gap-override: 0.00%;
+	size-adjust: 101.62%;
+  }
+  @font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: normal;
+	font-weight: 600;
+	src: local('Arial Bold');
+	ascent-override: 105.78%;
+	descent-override: 36.94%;
+	line-gap-override: 0.00%;
+	size-adjust: 95.57%;
+  }
+  @font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: italic;
+	font-weight: 600;
+	src: local('Arial Bold Italic');
+	ascent-override: 105.78%;
+	descent-override: 36.94%;
+	line-gap-override: 0.00%;
+	size-adjust: 95.57%;
+  }  
+  @font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: normal;
+	font-weight: 700;
+	src: local('Arial Bold');
+	ascent-override: 103.63%;
+	descent-override: 36.18%;
+	line-gap-override: 0.00%;
+	size-adjust: 97.56%;
+  }
+  @font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: italic;
+	font-weight: 700;
+	src: local('Arial Bold Italic');
+	ascent-override: 103.63%;
+	descent-override: 36.18%;
+	line-gap-override: 0.00%;
+	size-adjust: 97.56%;
+  }
+  @font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: normal;
+	font-weight: 800;
+	src: local('Arial Bold');
+	ascent-override: 101.35%;
+	descent-override: 35.39%;
+	line-gap-override: 0.00%;
+	size-adjust: 99.75%;
+  }
+  @font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: italic;
+	font-weight: 800;
+	src: local('Arial Bold Italic');
+	ascent-override: 101.35%;
+	descent-override: 35.39%;
+	line-gap-override: 0.00%;
+	size-adjust: 99.75%;
+  }
+  @font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: normal;
+	font-weight: 900;
+	src: local('Arial Bold');
+	ascent-override: 99.10%;
+	descent-override: 34.60%;
+	line-gap-override: 0.00%;
+	size-adjust: 102.02%;
+  }
+  @font-face {
+	font-family: 'Nunito Sans Fallback';
+	font-style: italic;
+	font-weight: 900;
+	src: local('Arial Bold Italic');
+	ascent-override: 99.10%;
+	descent-override: 34.60%;
+	line-gap-override: 0.00%;
+	size-adjust: 102.02%;
+  }
+  
+  

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -35,7 +35,7 @@ export default {
 				},
 			},
 			fontFamily: {
-				sans: ['Nunito Sans', ...defaultTheme.fontFamily.sans],
+				sans: ['Nunito Sans', 'Nunito Sans Fallback', ...defaultTheme.fontFamily.sans],
 			},
 			fontSize: {
 				// 1rem = 16px


### PR DESCRIPTION
Font Metric Overrides is a way to eliminate CLS introduced by the `font-swap` CSS property.

The overrides are manually inserted to `font.css`, with metric generated via CLI commands:
* `npx fontpie ./public/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-200.woff2 -weight 200 -style normal` 
* `npx fontpie ./public/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-300italic.woff2 -weight 300 -style italic`

Note that any custom fonts added would need to go through the same manual process, a potential (external?) CLI or postcss opportunity here!

## Screenshots

Before and After:

![](https://user-images.githubusercontent.com/84349818/243122111-3acabe59-4982-4bd5-8e34-10cce76847b8.png)

## References

* https://nalu.wiki/nalu/p/using-fonts-in-remix-216
* https://simonhearne.com/2021/layout-shifts-webfonts/
* https://www.npmjs.com/package/fontpie