### PR TITLE
ui(root): always render white user name color

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -198,7 +198,7 @@ function UserDropdown() {
 						alt={user.name ?? user.username}
 						src={getUserImgSrc(user.imageId)}
 					/>
-					<span className="text-body-sm font-bold">
+					<span className="text-body-sm font-bold text-white">
 						{user.name ?? user.username}
 					</span>
 				</Link>


### PR DESCRIPTION
Just started a new project and noticed there is a color contrast issue when rendering the user name in light mode.

## Screenshots

### Before
<img width="639" alt="Screen Shot 2023-06-03 at 5 02 18 PM" src="https://github.com/epicweb-dev/epic-stack/assets/8262156/2a934c35-a3ae-4878-b75a-13b7ccc47b7b">


### After
<img width="641" alt="Screen Shot 2023-06-03 at 5 01 43 PM" src="https://github.com/epicweb-dev/epic-stack/assets/8262156/d3c77f23-39e4-4e4b-b6da-28cd5e26e92c">

