### PR TITLE
dev-server execa command fails on Mac & Linux

### DIFF
--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -7,6 +7,7 @@ if (process.env.NODE_ENV === 'production') {
 		'tsx watch --clear-screen=false --ignore "app/**" --ignore "build/**" --ignore "node_modules/**" --inspect ./index.js'
 	execa(command, {
 		stdio: ['ignore', 'inherit', 'inherit'],
+		shell: true,
 		env: {
 			...process.env,
 			FORCE_COLOR: true,


### PR DESCRIPTION
resolves #136 

@kentcdodds 

see discussion on #136.

the fix is simply to add `shell: true` to `execa` options.
I've tested this fix on my Windows 11 and on Mac and Linux with `Oracle VM VirtualBox virtual machine`