### PR TITLE
Preload CSS and aggressive font caching

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -36,6 +36,7 @@ import { makeTimings, time } from './utils/timing.server.ts'
 
 export const links: LinksFunction = () => {
 	return [
+		// Preload CSS as a resource to avoid render blocking
 		{ rel: 'preload', href: fontStylestylesheetUrl, as: 'style' },
 		{ rel: 'preload', href: tailwindStylesheetUrl, as: 'style' },
 		cssBundleHref ? { rel: 'preload', href: cssBundleHref, as: 'style' } : null,
@@ -58,7 +59,6 @@ export const links: LinksFunction = () => {
 		},
 		{ rel: 'manifest', href: '/site.webmanifest' },
 		{ rel: 'icon', href: '/favicon.ico' },
-		// Preload CSS as a resource to avoid render blocking
 		{ rel: 'stylesheet', href: fontStylestylesheetUrl },
 		{ rel: 'stylesheet', href: tailwindStylesheetUrl },
 		cssBundleHref ? { rel: 'stylesheet', href: cssBundleHref } : null,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -36,6 +36,9 @@ import { makeTimings, time } from './utils/timing.server.ts'
 
 export const links: LinksFunction = () => {
 	return [
+		{ rel: 'preload', href: fontStylestylesheetUrl, as: 'style' },
+		{ rel: 'preload', href: tailwindStylesheetUrl, as: 'style' },
+		cssBundleHref ? { rel: 'preload', href: cssBundleHref, as: 'style' } : null,
 		{
 			rel: 'apple-touch-icon',
 			sizes: '180x180',
@@ -56,11 +59,8 @@ export const links: LinksFunction = () => {
 		{ rel: 'manifest', href: '/site.webmanifest' },
 		{ rel: 'icon', href: '/favicon.ico' },
 		// Preload CSS as a resource to avoid render blocking
-		{ rel: 'preload', href: fontStylestylesheetUrl, as: 'style' },
 		{ rel: 'stylesheet', href: fontStylestylesheetUrl },
-		{ rel: 'preload', href: tailwindStylesheetUrl, as: 'style' },
 		{ rel: 'stylesheet', href: tailwindStylesheetUrl },
-		cssBundleHref ? { rel: 'preload', href: cssBundleHref, as: 'style' } : null,
 		cssBundleHref ? { rel: 'stylesheet', href: cssBundleHref } : null,
 	].filter(Boolean)
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -55,8 +55,12 @@ export const links: LinksFunction = () => {
 		},
 		{ rel: 'manifest', href: '/site.webmanifest' },
 		{ rel: 'icon', href: '/favicon.ico' },
+		// Preload CSS as a resource to avoid render blocking
+		{ rel: 'preload', href: fontStylestylesheetUrl, as: 'style' },
 		{ rel: 'stylesheet', href: fontStylestylesheetUrl },
+		{ rel: 'preload', href: tailwindStylesheetUrl, as: 'style' },
 		{ rel: 'stylesheet', href: tailwindStylesheetUrl },
+		cssBundleHref ? { rel: 'preload', href: cssBundleHref, as: 'style' } : null,
 		cssBundleHref ? { rel: 'stylesheet', href: cssBundleHref } : null,
 	].filter(Boolean)
 }

--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -1,12 +1,12 @@
 ## Font Metric Overrides
 
-When using custom fonts, your site elements may stretch or shrink to accomodate the font. This is because the browser doesn't know the dimensions of the font you're using until it arrives, this introduces Cumulative Layout Shift and impact your web vitals. This is fixed in Epic Stack by introducing [Font Metric Overrides](https://github.com/epicweb-dev/epic-stack/pull/128/files) to our css.
+When using custom fonts, your site elements may stretch or shrink to accomodate the font. This is because the browser doesn't know the dimensions of the font you're using until it arrives, which introduces Cumulative Layout Shift and impact its web vitals. 
 
-### Adding Metric Overrides for Your Custom Fonts
+In Epic Stack, we fixed this by introducing [Font Metric Overrides](https://github.com/epicweb-dev/epic-stack/pull/128/files).
 
-Adding metric overrides for your custom fonts is a manual process. 
+### Custom Fonts Metric Overrides
 
-Add a font family fallback name to your `tailwind.config.js` file:
+Adding metric overrides for your custom fonts is a manual process. Add a font family fallback name to your `tailwind.config.js` file:
 
 ```js
     //tailwind.config.js
@@ -28,6 +28,8 @@ npx fontpie ./local/font/location.woff2 -w font-weight -s normal/italic -n YourF
 npx fontpie ./public/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-200.woff2 -w 200 -s normal -n NunitoSans
 ```
 
+Use fontpie for every custom font used (including variants) and add the metric overrides to `font.css`.
+
 ```css
 @font-face {
   font-family: 'NunitoSans Fallback';
@@ -41,6 +43,6 @@ npx fontpie ./public/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-200.woff2
 }
 ```
 
-Use fontpie for every custom font used (including variants) and add the metric overrides to `font.css`.
+*Ensure the original font has the `font-display: swap` property or the fallback wouldn't work!*
 
 That's it! You can now use your custom font without worrying about Cumulative Layout Shift!

--- a/server/index.ts
+++ b/server/index.ts
@@ -62,6 +62,13 @@ app.use(
 	'/build',
 	express.static('public/build', { immutable: true, maxAge: '1y' }),
 )
+
+// Aggressively cache fonts for a year
+app.use(
+	'/fonts',
+	express.static('public/fonts', { immutable: true, maxAge: '1y' }),
+);
+
 // Everything else (like favicon.ico) is cached for an hour. You may want to be
 // more aggressive with this caching.
 app.use(express.static('public', { maxAge: '1h' }))


### PR DESCRIPTION
A couple performance tweaks:

* By default, HTML rendering is paused until CSS stylesheets streamed in! We can fix this by preload CSS as a resource, 
* Currently, fonts are cached only a hour like everything else in the Public folder, so let's set the cache header for fonts folder to a year instead.