### PR TITLE
fix: restore package.json format in init script

### DIFF
--- a/remix.init/index.mjs
+++ b/remix.init/index.mjs
@@ -60,7 +60,7 @@ export default async function main({ isTypeScript, rootDirectory }) {
 	const fileOperationPromises = [
 		fs.writeFile(FLY_TOML_PATH, newFlyTomlContent),
 		fs.writeFile(ENV_PATH, newEnv),
-		fs.writeFile(PKG_PATH, JSON.stringify(packageJson)),
+		fs.writeFile(PKG_PATH, JSON.stringify(packageJson, null, 2)),
 		fs.copyFile(
 			path.join(rootDirectory, 'remix.init', 'gitignore'),
 			path.join(rootDirectory, '.gitignore'),


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
A recent change (https://github.com/epicweb-dev/epic-stack/commit/2c818d551b60254c2a6e914ab6dad8e76d9b887d) inside the init script caused the `package.json` file to lose the original formatting and resulted in everything being written in a single line.

Since this file is also inside `.prettierignore`, the formatting step being launched later doesn't fix it.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->
Create a new epic-stack app (pass your local repository to the `--template` option):

```sh
npx create-remix@latest --typescript --install --template epicweb-dev/epic-stack
```

Verify that `package.json` is formatted as expected, instead of being all in a single line.

### Alternative Solution

We could just remove `package.json` from `.prettierignore`, and let prettier handle it.