### PR TITLE
chore: remove `ENCRYPTION_SECRET` generation

### DIFF
--- a/remix.init/index.mjs
+++ b/remix.init/index.mjs
@@ -159,8 +159,8 @@ async function setupDeployment({ rootDirectory }) {
 	await $I`fly apps create ${APP_NAME}`
 
 	console.log(`🤫 Setting secrets in apps`)
-	await $I`fly secrets set SESSION_SECRET=${getRandomString32()} ENCRYPTION_SECRET=${getRandomString32()} INTERNAL_COMMAND_TOKEN=${getRandomString32()} --app ${APP_NAME}-staging`
-	await $I`fly secrets set SESSION_SECRET=${getRandomString32()} ENCRYPTION_SECRET=${getRandomString32()} INTERNAL_COMMAND_TOKEN=${getRandomString32()} --app ${APP_NAME}`
+	await $I`fly secrets set SESSION_SECRET=${getRandomString32()} INTERNAL_COMMAND_TOKEN=${getRandomString32()} --app ${APP_NAME}-staging`
+	await $I`fly secrets set SESSION_SECRET=${getRandomString32()} INTERNAL_COMMAND_TOKEN=${getRandomString32()} --app ${APP_NAME}`
 
 	console.log(
 		`🔊 Creating volumes. Answer "yes" when it warns you about downtime. You can add more volumes later (when you actually start getting paying customers �).`,


### PR DESCRIPTION
As mentioned in https://github.com/epicweb-dev/epic-stack/blob/main/docs/decisions/014-totp.md#consequences, we don't need these anymore