### PR TITLE
fix: report error

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -177,10 +177,22 @@ ${chalk.bold('Press Ctrl+C to stop')}
 	}
 })
 
-closeWithGrace(async () => {
+closeWithGrace(async ({ err }) => {
+	// log the error early
+	if (err) {
+		console.error(chalk.red(err))
+		console.error(chalk.red(err.stack))
+	}
+
+	// close up things
 	await new Promise((resolve, reject) => {
 		server.close(e => (e ? reject(e) : resolve('ok')))
 	})
+
+	// if there was an error, then exit with a failure code
+	if (err) {
+		process.exit(1)
+	}
 })
 
 // during dev, we'll keep the build module up to date with the changes

--- a/tests/mocks/index.ts
+++ b/tests/mocks/index.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import closeWithGrace from 'close-with-grace'
@@ -32,6 +33,12 @@ const server = setupServer(...handlers)
 server.listen({ onUnhandledRequest: 'warn' })
 console.info('🔶 Mock server installed')
 
-closeWithGrace(() => {
+closeWithGrace(({ err }) => {
 	server.close()
+	
+	if (err) {
+		console.error(chalk.red(err))
+		console.error(chalk.red(err.stack))
+		process.exit(1)
+	}
 })

--- a/tests/mocks/index.ts
+++ b/tests/mocks/index.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import closeWithGrace from 'close-with-grace'
@@ -33,12 +32,6 @@ const server = setupServer(...handlers)
 server.listen({ onUnhandledRequest: 'warn' })
 console.info('🔶 Mock server installed')
 
-closeWithGrace(({ err }) => {
+closeWithGrace(() => {
 	server.close()
-	
-	if (err) {
-		console.error(chalk.red(err))
-		console.error(chalk.red(err.stack))
-		process.exit(1)
-	}
 })


### PR DESCRIPTION
<!-- Summary: Put your summary here -->

## Test Plan
Hi! Many times I have experienced a situation where something happened during development and I couldn't see any error.
To give you an example.. I installed `lexical` and `@lexical/react`, which is a wysiwyg builder from Facebook. I think they don't provide ESM bundle or whatever. My point is that if you use it anywhere in the code like
```ts
import { LexicalComposer } from '@lexical/react/LexicalComposer.js';
console.log(LexicalComposer);
```

The build starts hanging
<img width="379" alt="image" src="https://github.com/epicweb-dev/epic-stack/assets/13948180/8a05532b-f98e-46cd-9a55-08e0b346896f">

There is no error to be viewed. I dug deeper and had to debug the code. Turns out, the `closeWithGrace` is called in `tests/mocks/index.ts`, it stops the mock server but does nothing else.

Not sure if this PR is the right approach, but at least it will report any errors in the console and closes the whole dev server.

With this change, it looks like this
<img width="882" alt="image" src="https://github.com/epicweb-dev/epic-stack/assets/13948180/c0d5c8bc-a6be-4613-b272-60aba31f3c7b">
