### PR TITLE
Fix username creation based on username rules

### DIFF
--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -11,7 +11,9 @@ export function createUser() {
 	const username = unique({
 		firstName: firstName.toLowerCase(),
 		lastName: lastName.toLowerCase(),
-	}).replace(/[^a-z0-9_]/g, '_')
+	})
+		.slice(0, 20)
+		.replace(/[^a-z0-9_]/g, '_')
 	return {
 		username,
 		name: `${firstName} ${lastName}`,

--- a/tests/e2e/onboarding.test.ts
+++ b/tests/e2e/onboarding.test.ts
@@ -17,7 +17,10 @@ function extractUrl(text: string) {
 test('onboarding with link', async ({ page }) => {
 	const firstName = faker.person.firstName()
 	const lastName = faker.person.lastName()
-	const username = faker.internet.userName({ firstName, lastName }).slice(0, 15)
+	const username = faker.internet
+		.userName({ firstName, lastName })
+		.slice(0, 15)
+		.replace(/[^a-z0-9_]/g, '_')
 	const onboardingData = {
 		name: `${firstName} ${lastName}`,
 		username,

--- a/tests/e2e/onboarding.test.ts
+++ b/tests/e2e/onboarding.test.ts
@@ -19,7 +19,7 @@ test('onboarding with link', async ({ page }) => {
 	const lastName = faker.person.lastName()
 	const username = faker.internet
 		.userName({ firstName, lastName })
-		.slice(0, 15)
+		.slice(0, 20)
 		.replace(/[^a-z0-9_]/g, '_')
 	const onboardingData = {
 		name: `${firstName} ${lastName}`,


### PR DESCRIPTION
This was causing flaky tests. If usernames exceeded 20 characters, the tests would fail. This fixes it.