### PR TITLE
speed up deployments by caching playwright browsers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,21 @@ jobs:
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
 
-      - name: 📥 Install Playwright Browsers
+      - name: 📥 Store Playwright's Version
+        run: |
+          PLAYWRIGHT_VERSION=$(npm ls @playwright/test | grep @playwright | sed 's/.*@//')
+          echo "Playwright's Version: $PLAYWRIGHT_VERSION"
+          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
+      
+      - name: 📥 Cache Playwright Browsers for Playwright's Versiont
+        id: cache-playwright-browsers
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
+      
+      - name: 📥 Setup Playwright
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
       - name: 🛠 Setup Database


### PR DESCRIPTION
Deployments tend to take some time (up to 8 mins at times) when `npx playwright install --with-deps` is executed. This PR implements caching for this step as NPM caching with `bahmutov/npm-install@v1`  doesn't take care of this.

## Test Plan

Merge this into a dev branch and checkout how the deployment improves timings. (Of course by running the deployment more than once.)

## Checklist

- [0 ] Tests updated
- [0] Docs 

<img width="1099" alt="Screenshot 2023-06-17 at 5 24 10 pm" src="https://github.com/epicweb-dev/epic-stack/assets/6100206/40dd870f-13d6-44ac-ae9c-3de4a1f06fc0">