### PR TITLE
Styling-with-css-variables-v2

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -141,12 +141,12 @@ function App() {
 				<meta name="viewport" content="width=device-width,initial-scale=1" />
 				<Links />
 			</head>
-			<body className="flex h-full flex-col justify-between bg-day-300 text-white dark:bg-night-700 ">
+			<body className="flex h-full flex-col justify-between bg-background text-foreground">
 				<header className="container mx-auto py-6">
 					<nav className="flex justify-between">
 						<Link to="/">
-							<div className="font-light text-black dark:text-white">epic</div>
-							<div className="font-bold text-black dark:text-white">notes</div>
+							<div className="font-light">epic</div>
+							<div className="font-bold">notes</div>
 						</Link>
 						<div className="flex items-center gap-10">
 							{user ? (
@@ -166,8 +166,8 @@ function App() {
 
 				<div className="container mx-auto flex justify-between">
 					<Link to="/">
-						<div className="font-light text-black dark:text-white">epic</div>
-						<div className="font-bold text-black dark:text-white">notes</div>
+						<div className="font-light">epic</div>
+						<div className="font-bold">notes</div>
 					</Link>
 					<ThemeSwitch userPreference={data.requestInfo.session.theme} />
 				</div>
@@ -197,7 +197,7 @@ function UserDropdown() {
 					to={`/users/${user.username}`}
 					// this is for progressive enhancement
 					onClick={e => e.preventDefault()}
-					className="flex items-center gap-2 rounded-full bg-night-500 py-2 pl-2 pr-4 outline-none hover:bg-night-400 focus:bg-night-400 radix-state-open:bg-night-400"
+					className="flex items-center gap-2 rounded-full bg-brand-500 py-2 pl-2 pr-4 outline-none hover:bg-brand-400 focus:bg-brand-400 radix-state-open:bg-brand-400"
 				>
 					<img
 						className="h-8 w-8 rounded-full object-cover"
@@ -219,7 +219,7 @@ function UserDropdown() {
 						<Link
 							prefetch="intent"
 							to={`/users/${user.username}`}
-							className="rounded-t-3xl px-7 py-5 outline-none hover:bg-night-500 radix-highlighted:bg-night-500"
+							className="rounded-t-3xl px-7 py-5 outline-none hover:bg-brand-500 radix-highlighted:bg-brand-500"
 						>
 							Profile
 						</Link>
@@ -228,7 +228,7 @@ function UserDropdown() {
 						<Link
 							prefetch="intent"
 							to={`/users/${user.username}/notes`}
-							className="px-7 py-5 outline-none hover:bg-night-500 radix-highlighted:bg-night-500"
+							className="px-7 py-5 outline-none hover:bg-brand-500 radix-highlighted:bg-brand-500"
 						>
 							Notes
 						</Link>
@@ -237,7 +237,7 @@ function UserDropdown() {
 						<Form
 							action="/logout"
 							method="POST"
-							className="rounded-b-3xl px-7 py-5 outline-none radix-highlighted:bg-night-500"
+							className="rounded-b-3xl px-7 py-5 outline-none radix-highlighted:bg-brand-500"
 							onClick={e => submit(e.currentTarget)}
 						>
 							<button type="submit">Logout</button>

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -1,3 +1,34 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+	:root {
+		--color-background: 240 51% 91%; /* day-300 */
+		--color-foreground: 0 0% 0%; /* black */
+		--color-100: 252 100% 98%; /* day-100 */
+		--color-200: 240 74% 94%; /* day-200 */
+		--color-300: 240 51% 91%; /* day-300 */
+		--color-400: 240 34% 86%; /* day-400 */
+		--color-500: 240 54% 73%; /* day-500 */
+		--color-600: 240 33% 70%; /* day-600 */
+		--color-700: 252 100% 63%; /* day-700 */
+		--color-accent-purple: 252 100% 63%;
+		--color-accent-pink: 293 100% 76%;
+		--color-accent-yellow: 40 100% 62%;
+		--color-accent-yellow-muted: 43 100% 69%;
+		--color-accent-red: 0 82% 65%;
+	}
+
+	.dark {
+		--color-background: 0 0% 4%; /* night-700 */
+		--color-foreground: 0 0% 100%; /* white */
+		--color-100: 0 0% 85%; /* night-100 */
+		--color-200: 0 0% 67%; /* night-200 */
+		--color-300: 0 0% 44%; /* night-300 */
+		--color-400: 0 0% 29%; /* night-400 */
+		--color-500: 240 3% 12%; /* night-500 */
+		--color-600: 0 0% 8%; /* night-600 */
+		--color-700: 0 0% 4%; /* night-700 */
+	}
+}

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -6,13 +6,20 @@
 	:root {
 		--color-background: 240 51% 91%; /* day-300 */
 		--color-foreground: 0 0% 0%; /* black */
-		--color-100: 252 100% 98%; /* day-100 */
-		--color-200: 240 74% 94%; /* day-200 */
-		--color-300: 240 51% 91%; /* day-300 */
-		--color-400: 240 34% 86%; /* day-400 */
-		--color-500: 240 54% 73%; /* day-500 */
-		--color-600: 240 33% 70%; /* day-600 */
-		--color-700: 252 100% 63%; /* day-700 */
+		--color-day-100: 252 100% 98%; /* day-100 */
+		--color-day-200: 240 74% 94%; /* day-200 */
+		--color-day-300: 240 51% 91%; /* day-300 */
+		--color-day-400: 240 34% 86%; /* day-400 */
+		--color-day-500: 240 54% 73%; /* day-500 */
+		--color-day-600: 240 33% 70%; /* day-600 */
+		--color-day-700: 252 100% 63%; /* day-700 */
+		--color-night-100: 0 0% 85%; /* night-100 */
+		--color-night-200: 0 0% 67%; /* night-200 */
+		--color-night-300: 0 0% 44%; /* night-300 */
+		--color-night-400: 0 0% 29%; /* night-400 */
+		--color-night-500: 240 3% 12%; /* night-500 */
+		--color-night-600: 0 0% 8%; /* night-600 */
+		--color-night-700: 0 0% 4%; /* night-700 */
 		--color-accent-purple: 252 100% 63%;
 		--color-accent-pink: 293 100% 76%;
 		--color-accent-yellow: 40 100% 62%;
@@ -23,12 +30,5 @@
 	.dark {
 		--color-background: 0 0% 4%; /* night-700 */
 		--color-foreground: 0 0% 100%; /* white */
-		--color-100: 0 0% 85%; /* night-100 */
-		--color-200: 0 0% 67%; /* night-200 */
-		--color-300: 0 0% 44%; /* night-300 */
-		--color-400: 0 0% 29%; /* night-400 */
-		--color-500: 240 3% 12%; /* night-500 */
-		--color-600: 0 0% 8%; /* night-600 */
-		--color-700: 0 0% 4%; /* night-700 */
 	}
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,30 +8,23 @@ export default {
 	theme: {
 		extend: {
 			colors: {
-				night: {
-					100: '#DADADA',
-					200: '#AAAAAA',
-					300: '#717171',
-					400: '#494949',
-					500: '#1E1E20',
-					600: '#141414',
-					700: '#090909',
-				},
-				day: {
-					100: '#F7F5FF',
-					200: '#E4E4FB',
-					300: '#DDDDF4',
-					400: '#D0D0E8',
-					500: '#9696E0',
-					600: '#9999CC',
-					700: '#6A44FF',
+				background: 'hsl(var(--color-background))',
+				foreground: 'hsl(var(--color-foreground))',
+				brand: {
+					100: 'hsl(var(--color-100))',
+					200: 'hsl(var(--color-200))',
+					300: 'hsl(var(--color-300))',
+					400: 'hsl(var(--color-400))',
+					500: 'hsl(var(--color-500))',
+					600: 'hsl(var(--color-600))',
+					700: 'hsl(var(--color-700))',
 				},
 				accent: {
-					purple: '#6A44FF',
-					pink: '#F183FF',
-					yellow: '#FFBE3F',
-					'yellow-muted': '#FFD262',
-					red: '#EF5A5A',
+					purple: 'hsl(var(--color-accent-purple))',
+					pink: 'hsl(var(--color-accent-pink))',
+					yellow: 'hsl(var(--color-accent-yellow))',
+					'yellow-muted': 'hsl(var(--color-accent-yellow-muted))',
+					red: 'hsl(var(--color-accent-red))',
 				},
 			},
 			fontFamily: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,14 +10,23 @@ export default {
 			colors: {
 				background: 'hsl(var(--color-background))',
 				foreground: 'hsl(var(--color-foreground))',
-				brand: {
-					100: 'hsl(var(--color-100))',
-					200: 'hsl(var(--color-200))',
-					300: 'hsl(var(--color-300))',
-					400: 'hsl(var(--color-400))',
-					500: 'hsl(var(--color-500))',
-					600: 'hsl(var(--color-600))',
-					700: 'hsl(var(--color-700))',
+				day: {
+					100: 'hsl(var(--color-day-100))',
+					200: 'hsl(var(--color-day-200))',
+					300: 'hsl(var(--color-day-300))',
+					400: 'hsl(var(--color-day-400))',
+					500: 'hsl(var(--color-day-500))',
+					600: 'hsl(var(--color-day-600))',
+					700: 'hsl(var(--color-day-700))',
+				},
+				night: {
+					100: 'hsl(var(--color-night-100))',
+					200: 'hsl(var(--color-night-200))',
+					300: 'hsl(var(--color-night-300))',
+					400: 'hsl(var(--color-night-400))',
+					500: 'hsl(var(--color-night-500))',
+					600: 'hsl(var(--color-night-600))',
+					700: 'hsl(var(--color-night-700))',
 				},
 				accent: {
 					purple: 'hsl(var(--color-accent-purple))',


### PR DESCRIPTION
Added theming based on CSS Vars.

With this strategy, semantic classes (success, danger, warning, info, brand) make more sense than literal classes (red, purple, pink, etc). Because you use both literal (red, purple, etc) and semantic (day, night), and you wanted to keep them, I kept them there, but I'd suggest going for exclusively semantic classes.

Here's how I configure my own projects:
```ts
// ...
			colors: {
				background: 'rgb(var(--color-background))',
				foreground: 'rgb(var(--color-foreground))',
				brand: {
					DEFAULT: 'rgb(var(--color-brand))',
					muted: 'rgb(var(--color-brand-muted))',
				},
				success: {
					title: 'rgb(var(--color-success-title))',
					DEFAULT: 'rgb(var(--color-success-foreground))',
					background: 'rgb(var(--color-success-background))',
				},
				info: {
					title: 'rgb(var(--color-info-title))',
					DEFAULT: 'rgb(var(--color-info-foreground))',
					background: 'rgb(var(--color-info-background))',
				},
				warning: {
					title: 'rgb(var(--color-warning-title))',
					DEFAULT: 'rgb(var(--color-warning-foreground))',
					background: 'rgb(var(--color-warning-background))',
				},
				danger: {
					title: 'rgb(var(--color-danger-title))',
					DEFAULT: 'rgb(var(--color-danger-foreground))',
					background: 'rgb(var(--color-danger-background))',
				},
				'muted-50': 'rgb(var(--color-muted-50))',
				'muted-100': 'rgb(var(--color-muted-100))',
				'muted-200': 'rgb(var(--color-muted-200))',
				'muted-300': 'rgb(var(--color-muted-300))',
				'muted-400': 'rgb(var(--color-muted-400))',
				'muted-500': 'rgb(var(--color-muted-500))',
				'muted-600': 'rgb(var(--color-muted-600))',
				'muted-700': 'rgb(var(--color-muted-700))',
				'muted-800': 'rgb(var(--color-muted-800))',
				'muted-900': 'rgb(var(--color-muted-900))',
				'muted-950': 'rgb(var(--color-muted-950))',
				ring: 'rgb(var(--ring))',
			},
// ...
```

Then I just adjust these values in dark mode.