### PR TITLE
wrap table names in quotes

### DIFF
--- a/tests/setup/utils.ts
+++ b/tests/setup/utils.ts
@@ -85,7 +85,7 @@ export function deleteAllData() {
 
 	// Delete all data in each table in the proper order
 	for (const tableName of sortedTableNames) {
-		db.prepare(`DELETE FROM ${tableName}`).run()
+		db.prepare(`DELETE FROM "${tableName}"`).run()
 	}
 
 	db.close()


### PR DESCRIPTION
I started getting "SqliteError: near "Order": syntax error" after migrating my db and running tests. After a long while
I think I found the 'bug' was due to my model being named 'Order' which is a SQL keyword. 

By wrapping the table names in quotes solves this issue.

This is my first PR ever so I hope I'm not doing something wrong! ... about to click the green button...