### PR TITLE
support inline usage of color-scheme CSS property

### DIFF
--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -4,6 +4,7 @@
 
 @layer base {
 	:root {
+		color-scheme: light;
 		--color-background: 240 51% 91%; /* day-300 */
 		--color-foreground: 0 0% 0%; /* black */
 		--color-brand-primary: 252 100% 63%;
@@ -29,6 +30,7 @@
 	}
 
 	.dark {
+		color-scheme: dark;
 		--color-background: 0 0% 4%; /* night-700 */
 		--color-foreground: 0 0% 100%; /* white */
 	}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme This CSS property is used to specify the preferred color scheme to use in the supported user agent.

In the context of this app the scroll bars now match the selected theme.

Also dropped in  `theme-color` meta support

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->

BEFORE
<img width="1099" alt="Screenshot 2023-06-19 at 7 03 44 pm" src="https://github.com/epicweb-dev/epic-stack/assets/6100206/39735e15-8f8e-4c07-bd9d-21db32215191">

AFTER
<img width="1099" alt="Screenshot 2023-06-19 at 7 04 24 pm" src="https://github.com/epicweb-dev/epic-stack/assets/6100206/95bf72cf-ccda-4e71-a2d1-46a4797f75a2">






