### PR TITLE
devops: do not cache Playwright browsers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,21 +91,7 @@ jobs:
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
 
-      - name: 📥 Store Playwright's Version
-        run: |
-          PLAYWRIGHT_VERSION=$(npm ls @playwright/test | grep @playwright | sed 's/.*@//')
-          echo "Playwright's Version: $PLAYWRIGHT_VERSION"
-          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
-      
-      - name: 📥 Cache Playwright Browsers for Playwright's Versiont
-        id: cache-playwright-browsers
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
-      
-      - name: 📥 Setup Playwright
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+      - name: 📥 Install Playwright Browsers
         run: npx playwright install --with-deps
 
       - name: 🛠 Setup Database

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: 📥 Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npm run test:e2e:install
 
       - name: 🛠 Setup Database
         run: npx prisma migrate deploy

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:e2e:dev": "playwright test --ui",
     "pretest:e2e:run": "npm run build",
     "test:e2e:run": "cross-env CI=true playwright test",
-    "test:e2e:install": "npx playwright install chromium --with-deps",
+    "test:e2e:install": "npx playwright install --with-deps chromium",
     "typecheck": "tsc",
     "validate": "run-p \"test -- --run\" lint typecheck test:e2e:run"
   },


### PR DESCRIPTION
Caching browsers is actually **not recommended** since the amount of time it saves, is usually the same as the amount it takes to restore it from the cache (to cache the browser binaries).

We need to understand that there are browser binaries (cacheable) and system dependencies which are installed via apt (not cacheable).

Since we are only testing with Chromium, GitHub Actions already has most of the system dependencies installed, which are required to launch Chromium. If you would test in WebKit or Firefox it would end up in errors, that the system dependencies are not there, e.g. WebKit is not able to launch, since you install the system dependencies conditionally after https://github.com/epicweb-dev/epic-stack/pull/192. So it was working more by accident.

This PR reverts https://github.com/epicweb-dev/epic-stack/pull/192, makes a pure cosmetic change to the `package.json` and then instead of installing all the browsers which we did before (npx playwright install), now we only install chromium, as well as only the chromium dependencies, this should make it already much faster. I re-use this from the package.json.