### PR TITLE
fix flaky e2e onboarding test

### DIFF
--- a/app/routes/resources+/theme/index.tsx
+++ b/app/routes/resources+/theme/index.tsx
@@ -72,7 +72,7 @@ export function ThemeSwitch({
 	}, [])
 
 	const [form] = useForm({
-		id: 'onboarding',
+		id: 'theme-switch',
 		lastSubmission: fetcher.data?.submission,
 		onValidate({ formData }) {
 			return parse(formData, { schema: ThemeFormSchema })


### PR DESCRIPTION
```
 1) [chromium] › onboarding.test.ts:17:1 › onboarding with link ───────────────────────────────────

    Error: Timed out 5000ms waiting for expect(received).toHaveURL(expected)

    Expected string: "http://localhost:3000/"
    Received string: "http://localhost:3000/onboarding"
    Call log:
      - expect.toHaveURL with timeout 5000ms
      - waiting for locator(':root')
      -   locator resolved to <html lang="en" class="light">…</html>
      -   unexpected value "http://localhost:3000/onboarding"
      -   locator resolved to <html lang="en" class="light">…</html>
      -   unexpected value "http://localhost:3000/onboarding"
      -   locator resolved to <html lang="en" class="light">…</html>
      -   unexpected value "http://localhost:3000/onboarding"
      -   locator resolved to <html lang="en" class="light">…</html>
      -   unexpected value "http://localhost:3000/onboarding"
      -   locator resolved to <html lang="en" class="light">…</html>
      -   unexpected value "http://localhost:3000/onboarding"
      -   locator resolved to <html lang="en" class="light">…</html>
      -   unexpected value "http://localhost:3000/onboarding"
      -   locator resolved to <html lang="en" class="light">…</html>
      -   unexpected value "http://localhost:3000/onboarding"
      -   locator resolved to <html lang="en" class="light">…</html>
      -   unexpected value "http://localhost:3000/onboarding"
      -   locator resolved to <html lang="en" class="light">…</html>
      -   unexpected value "http://localhost:3000/onboarding"


      70 |
      71 | 	await page.getByLabel(/^confirm password/i).fill(onboardingData.password)
    > 72 |
         | ^
      73 | 	await page.getByLabel(/terms/i).check()
      74 |
      75 | 	await page.getByLabel(/offers/i).check()

        at /home/runner/work/bookit/bookit/tests/e2e/onboarding.test.ts:72:22

```




