### PR TITLE
Update cookie expiration logic for "remember me" feature

### DIFF
--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -111,7 +111,7 @@ export async function action({ request }: DataFunctionArgs) {
 	cookieSession.unset(onboardingEmailSessionKey)
 
 	const newCookie = await commitSession(cookieSession, {
-		expires: remember ? session.expirationDate : undefined,
+		expires: remember ?  undefined : session.expirationDate,
 	})
 	return redirect(safeRedirect(redirectTo, '/'), {
 		headers: { 'Set-Cookie': newCookie },

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -111,7 +111,7 @@ export async function action({ request }: DataFunctionArgs) {
 	cookieSession.unset(onboardingEmailSessionKey)
 
 	const newCookie = await commitSession(cookieSession, {
-		expires: remember ?  undefined : session.expirationDate,
+		expires: remember ? session.expirationDate : undefined,
 	})
 	return redirect(safeRedirect(redirectTo, '/'), {
 		headers: { 'Set-Cookie': newCookie },

--- a/app/routes/resources+/login.tsx
+++ b/app/routes/resources+/login.tsx
@@ -71,7 +71,7 @@ export async function action({ request }: DataFunctionArgs) {
 
 	const session = await prisma.session.findUnique({
 		where: { id: sessionId },
-		select: { userId: true },
+		select: { userId: true, expirationDate: true },
 	})
 	invariant(session, 'newly created session not found')
 
@@ -88,8 +88,8 @@ export async function action({ request }: DataFunctionArgs) {
 		headers: {
 			'Set-Cookie': await commitSession(cookieSession, {
 				maxAge: remember
-					? undefined
-					: 60 * 60 * 24 * 7 // 7 days
+					? session.expirationDate
+					: undefined
 			}),
 		},
 	}

--- a/app/routes/resources+/login.tsx
+++ b/app/routes/resources+/login.tsx
@@ -88,8 +88,8 @@ export async function action({ request }: DataFunctionArgs) {
 		headers: {
 			'Set-Cookie': await commitSession(cookieSession, {
 				maxAge: remember
-					? 60 * 60 * 24 * 7 // 7 days
-					: undefined,
+					? undefined
+					: 60 * 60 * 24 * 7 // 7 days
 			}),
 		},
 	}

--- a/app/routes/resources+/login.tsx
+++ b/app/routes/resources+/login.tsx
@@ -87,7 +87,7 @@ export async function action({ request }: DataFunctionArgs) {
 	const responseInit = {
 		headers: {
 			'Set-Cookie': await commitSession(cookieSession, {
-				maxAge: remember
+				expires: remember
 					? session.expirationDate
 					: undefined
 			}),


### PR DESCRIPTION
When "remember me" is checked, rather than using a hard-coded value as `maxAge`, `expires` value should be set to session.expirationDate

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

The expiration date in the login flow is now 30 days after login date (same as onboarding flow) rather than 7 days

https://github.com/epicweb-dev/epic-stack/assets/82935610/9ad0b3e2-27d6-41ba-9889-c2f7bb133f57






