### PR TITLE
image links now link to the intended links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 npx create-remix@latest --typescript --install --template epicweb-dev/epic-stack
 ```
 
-[![The Epic Stack](https://github.com/epicweb-dev/epic-stack/assets/1500684/1b00286c-aa3d-44b2-9ef2-04f694eb3592)](https://www.epicweb.dev/epic-stack)
+[![The Epic Stack](https://github-production-user-asset-6210df.s3.amazonaws.com/1500684/246885449-1b00286c-aa3d-44b2-9ef2-04f694eb3592.png)](https://www.epicweb.dev/epic-stack)
 
 [The Epic Stack](https://www.epicweb.dev/epic-stack)
 
@@ -23,7 +23,7 @@ npx create-remix@latest --typescript --install --template epicweb-dev/epic-stack
 
 ## Watch Kent's Introduction to The Epic Stack
 
-[![screenshot of a YouTube video](https://github.com/epicweb-dev/epic-stack/assets/1500684/6beafa78-41c6-47e1-b999-08d3d3e5cb57)](https://www.youtube.com/watch?v=yMK5SVRASxM)
+[![screenshot of a YouTube video](https://github-production-user-asset-6210df.s3.amazonaws.com/1500684/242088051-6beafa78-41c6-47e1-b999-08d3d3e5cb57.png)](https://www.youtube.com/watch?v=yMK5SVRASxM)
 
 ["The Epic Stack" by Kent C. Dodds at #RemixConf 2023 💿](https://www.youtube.com/watch?v=yMK5SVRASxM)
 


### PR DESCRIPTION
<!--
Title: Fix image links in README.md

Summary: Updated image links in README.md to point to the correct underlying URLs. Currently they open the images in a new tab, not the underlying image links.

-->

## Test Plan

1. Verify that the modified image links in README.md now point to the correct URLs.
2. Ensure that clicking the images navigates to the intended destination.

## Checklist

- [x] Tests updated
- [x] Docs updated

## Screenshots

*No visual changes in the app; changes were limited to the README.md file.*