### PR TITLE
feat: devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+  "name": "app",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "remoteUser": "node",
+  "postCreateCommand": [".devcontainer/post-create.sh"],
+  "containerEnv": {
+    "NODE_ENV": "development"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": {
+      "packages": "sudo"
+    },
+    "ghcr.io/wxw-matt/devcontainer-features/command_runner:latest": {
+      "command1": "echo 'node ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/node"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "prisma.prisma",
+        "bradlc.vscode-tailwindcss"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: ../other/Dockerfile
+      target: base
+
+    volumes:
+      - ../:/workspace:cached
+      - app_node_modules:/workspace/node_modules
+
+    command: sleep infinity
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  app_node_modules:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [ -n "${REMOTE_CONTAINERS}" ]; then
+	this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
+	workspace_root=$(realpath ${this_dir}/..)
+
+	#
+	# do 1-time post-container-create tasks that are
+	# needed by all users of this devcontainer.
+	sudo chown -R node:node node_modules
+
+	#
+	# if defined, run the local post-container-create logic
+	# for a given developer working on the project [optional]
+	local_post_create_file="${this_dir}/post-create.local.sh"
+	if [ -f "${local_post_create_file}" ]; then
+		"${local_post_create_file}"
+	fi
+
+	unset this_dir
+	unset workspace_root
+	unset local_post_create_file
+fi

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,14 +2,14 @@
 
 set -eo pipefail
 
-if [ -n "${REMOTE_CONTAINERS}" ]; then
-	this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
-	workspace_root=$(realpath ${this_dir}/..)
+this_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)
+workspace_root=$(realpath ${this_dir}/..)
 
+if [ -n "${REMOTE_CONTAINERS}" ]; then
 	#
 	# do 1-time post-container-create tasks that are
-	# needed by all users of this devcontainer.
-	sudo chown -R node:node node_modules
+	# needed by all users of this local devcontainer.
+	sudo chown -R node:node "${workspace_root}/node_modules"
 
 	#
 	# if defined, run the local post-container-create logic
@@ -18,8 +18,15 @@ if [ -n "${REMOTE_CONTAINERS}" ]; then
 	if [ -f "${local_post_create_file}" ]; then
 		"${local_post_create_file}"
 	fi
-
-	unset this_dir
-	unset workspace_root
-	unset local_post_create_file
 fi
+
+if [ -n "${CODESPACES}" ]; then
+	#
+	# do 1-time post-container-create tasks that are
+	# needed by all users of this GitHub Codespace.
+	sudo chown -R node:node "${workspace_root}/node_modules"
+fi
+
+unset this_dir
+unset workspace_root
+unset local_post_create_file


### PR DESCRIPTION
This PR adds `devcontainer` configuration files to the `Epic Stack`.

You can find a lot more info about `devcontainers` on the [VS Code Docs](https://code.visualstudio.com/docs/devcontainers/containers) page about them as well as on the [devcontainer specification](https://containers.dev/), but the `tl;dr` is that this set of configurations allows Epic Stack projects to leverage remote development environments such as **GitHub Codespaces**, **Gitpod**, **VS Code Remote Containers** (machine-local docker container), and a growing list of other supported providers.

This is the underpinning of how GitHub themselves [does development on the GitHub web application](https://github.blog/2021-08-11-githubs-engineering-team-moved-codespaces/) and it's an incredible value-add, especially for open source repositories because it can lower the barrier to entry significantly for new contributors by getting rid of so many potential stumbling blocks related to environment setup.

For the Epic Stack, the configurations leverage the existing multi-stage docker build setup found in `other/Dockerfile` so that the development environment provided to developers is _nearly identical_ to that which will run in production (with the minor difference that the devcontainer also adds `git` and `sudo` which are utilities not present in the production image.

## Test Plan

Spin up your own Codespace in GitHub against this branch, and after a few minutes of bootstrapping (which only happens once at Codespace creation but doesn't happen on subsequent re-starts of the Codespace) you are plopped into the web version of VS Code and everything works just like you were developing locally, except your code will be running on GitHub servers and your dev environment will spin up against real-looking GitHub subdomains instead of "localhost" urls!

Now anybody can code on their Epic Stack application from any device that can run VS Code in the browser (yes, it works on phones)!

## Checklist

- [ ] Tests updated
- [ ] Docs updated

Tests are not really applicable to this change.

## Screenshots

**Demo in VS Code (_running locally with the "remote" environment being a docker container_)**
https://youtu.be/3R8H_AMZ6PI

**Demo in GitHub Codespaces (_running in the cloud on GitHub hardware_)**
https://youtu.be/XP_y0w0wWJk

