### PR TITLE
Replace deprecated no-duplicate-imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,7 +18,7 @@ module.exports = {
 				fixStyle: 'inline-type-imports',
 			},
 		],
-		'@typescript-eslint/no-duplicate-imports': 'warn',
+		'import/no-duplicates': 'warn',
 	},
 	overrides: [
 		{


### PR DESCRIPTION
This typescript-eslint [no-duplicate-imports rule has been deprecated](https://typescript-eslint.io/rules/no-duplicate-imports/)

It's replacement, [import/no-duplicates](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-duplicates.md), has more options to configure **but more importantly it's autofixable**