### PR TITLE
Make check in checkbox visible in lightmode

### DIFF
--- a/app/components/ui/checkbox.tsx
+++ b/app/components/ui/checkbox.tsx
@@ -26,7 +26,7 @@ const Checkbox = React.forwardRef<
 			className={cn('flex items-center justify-center text-current')}
 		>
 			<svg viewBox="0 0 8 8">
-				<path d="M1,4 L3,6 L7,2" stroke="black" strokeWidth="1" fill="none" />
+				<path d="M1,4 L3,6 L7,2" stroke="currentcolor" strokeWidth="1" fill="none" />
 			</svg>
 		</CheckboxPrimitive.Indicator>
 	</CheckboxPrimitive.Root>


### PR DESCRIPTION
This tiny PR fixes the checkbox component by changing the checkbox indicator svg's stroke color from "black" to "currentcolor" so that the checkbox displays properly in light mode.

## Test Plan

This seemed small enough to test manually :stuck_out_tongue: 

## Checklist

No changes to tests or docs

## Screenshots

Before: 
![image](https://github.com/epicweb-dev/epic-stack/assets/93843523/e9117ed3-31af-49b1-94e8-d1894676791b)

After:
![image](https://github.com/epicweb-dev/epic-stack/assets/93843523/a9bfb7da-b089-4899-b9d5-10847e65b0d7)

