### PR TITLE
(examples): Add epic-stack-with-storybook

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -26,6 +26,9 @@ This page links to examples of how to implement some things with the Epic Stack.
   [@L-Steinmacher](https://github.com/L-Steinmacher/epic-stack-with-prisma-client-extensions):
   An example of the Epic Stack with Prisma Client extensions activated for enum
   like behavior in SQLite.
+- [Epic Stack + Storybook](https://github.com/moishinetzer/epic-stack-with-storybook): by
+  [@moishinetzer](https://github.com/moishinetzer): An example of the Epic Stack
+  with Storybook. It also showcases creating a Remix stub, which is very helpful for isolating Remix-specific components inside of Storybook.
 
 ## How to contribute
 


### PR DESCRIPTION
This example showcases storybook usage with the epic-stack. If there is interest to integrate this in the epic-stack I would be more than happy to expand the example and add chromatic tests and add those as part of the CI/CD pipeline.

The shadcn/ui components don't have stories as those are fairly trivial and follow the same pattern as shown in the other stories already implemented.

@kentcdodds I really do believe there is a very strong point to add storybook to the main epic-stack repo, so I would love to hear what your thoughts are after seeing this.