### PR TITLE
fix(totp): algorithm name changed to uppercase

### DIFF
--- a/app/routes/_auth+/forgot-password/index.tsx
+++ b/app/routes/_auth+/forgot-password/index.tsx
@@ -70,7 +70,7 @@ export async function action({ request }: DataFunctionArgs) {
 		// don't leak the association between the two.
 		const target = usernameOrEmail
 		const { otp, secret, algorithm, period, digits } = generateTOTP({
-			algorithm: 'sha256',
+			algorithm: 'SHA256',
 			period: tenMinutesInSeconds,
 		})
 		// delete old verifications. Users should not have more than one verification

--- a/app/routes/_auth+/signup/index.tsx
+++ b/app/routes/_auth+/signup/index.tsx
@@ -69,7 +69,7 @@ export async function action({ request }: DataFunctionArgs) {
 
 	const thirtyMinutesInSeconds = 30 * 60
 	const { otp, secret, algorithm, period, digits } = generateTOTP({
-		algorithm: 'sha256',
+		algorithm: 'SHA256',
 		period: thirtyMinutesInSeconds,
 	})
 	// delete old verifications. Users should not have more than one verification

--- a/app/utils/totp.server.test.ts
+++ b/app/utils/totp.server.test.ts
@@ -10,7 +10,7 @@ test('OTP can be generated and verified', () => {
 	const { secret, otp, algorithm, period } = totp.generateTOTP()
 	const result = totp.verifyTOTP({ otp, secret })
 	expect(result).toEqual({ delta: 0 })
-	expect(algorithm).toBe('sha1')
+	expect(algorithm).toBe('SHA1')
 	expect(period).toBe(30)
 })
 
@@ -56,13 +56,24 @@ test('Setting a different seconds config for generating and verifying will fail'
 })
 
 test('Setting a different algo config for generating and verifying will fail', () => {
-	const desiredAlgo = 'sha512'
+	const desiredAlgo = 'SHA512'
 	const { otp, secret, algorithm } = totp.generateTOTP({
 		algorithm: desiredAlgo,
 	})
 	expect(algorithm).toBe(desiredAlgo)
-	const result = totp.verifyTOTP({ otp, secret, algorithm: 'sha1' })
+	const result = totp.verifyTOTP({ otp, secret, algorithm: 'SHA1' })
 	expect(result).toBeNull()
+})
+
+test('Generating and verifying also works with the algorithm name alias', () => {
+	const desiredAlgo = 'SHA1'
+	const { otp, secret, algorithm } = totp.generateTOTP({
+		algorithm: desiredAlgo,
+	})
+	expect(algorithm).toBe(desiredAlgo)
+
+	const result = totp.verifyTOTP({ otp, secret, algorithm: 'sha1' })
+	expect(result).not.toBeNull()
 })
 
 test('OTP Auth URI can be generated', () => {

--- a/app/utils/totp.server.ts
+++ b/app/utils/totp.server.ts
@@ -1,7 +1,7 @@
 /**
  * This was copy/paste/modified from https://npm.im/notp (MIT)
  *
- * The primary motivation was to support a more secure algorithm than sha1.
+ * The primary motivation was to support a more secure algorithm than SHA1.
  * The maintainer has not actively responded to issues or pull requests in years.
  *
  * Some improvements were made to modernize the code (which was last published in 2014).
@@ -32,9 +32,9 @@ import * as base32 from 'thirty-two'
 // SHA1 is not secure, but in the context of TOTPs, it's unrealistic to expect
 // security issues. Also, it's the default for compatibility with OTP apps.
 // That said, if you're acting the role of both client and server and your TOTP
-// is longer lived, you can definitely use a more secure algorithm like sha256.
+// is longer lived, you can definitely use a more secure algorithm like SHA256.
 // Learn more: https://www.rfc-editor.org/rfc/rfc4226#page-25 (B.1. SHA-1 Status)
-const DEFAULT_ALGORITHM = 'sha1'
+const DEFAULT_ALGORITHM = 'SHA1'
 const DEFAULT_DIGITS = 6
 const DEFAULT_WINDOW = 1
 const DEFAULT_PERIOD = 30
@@ -89,7 +89,7 @@ function verifyHOTP(
  * @param options Configuration options for the TOTP.
  * @param options.period The number of seconds for the OTP to be valid. Defaults to 30.
  * @param options.digits The length of the OTP. Defaults to 6.
- * @param options.algorithm The algorithm to use. Defaults to sha1.
+ * @param options.algorithm The algorithm to use. Defaults to SHA1.
  * @param options.secret The secret to use for the TOTP. Defaults to a random secret.
  * @returns The OTP, secret, and config options used to generate the OTP.
  */


### PR DESCRIPTION
to support google authenticator without breaking other totp verifier. see #257 

Unlike other authenticator apps, google authenticator only allows the algorithms listed in the [documentation](https://github.com/google/google-authenticator/wiki/Key-Uri-Format#algorithm). That is `SHA1`, instead of `sha1`. 

> Currently, the algorithm parameter is ignored by the Google Authenticator implementations.

Contrary to what the documentation suggests, this value is read and used!

It is very difficult to say which spelling is the correct one. If you look at the [node.js crypto documentation](https://nodejs.org/api/crypto.html#cryptocreatehashalgorithm-options), the lower case is preferred in any case. 

The function `crypto.getHashes()` returns here also only the lower case.

But in the source code of openssl you can find both variants. An alias ensures that both notations are valid. 

I added a test `Generating and verifying also works with the algorithm name alias` to ensure that both notations produce the same result.

To create consistency, I have adapted the algorithm name even with other usage e.g. forgot-password.

## Test Plan

- [x] Test openssl behaviour with different algorithm names
      ✅ `openssl dgst -SHA1`
      ✅ `openssl dgst -sha1`
      ❌ `openssl dgst -ShA1`
- [x] Test with google authenticator
- [x] Test with Microsoft Authenticator
- [ ] Test with Authy

## Checklist

- [ ] Tests updated
- [ ] Docs updated



