### PR TITLE
feat(totp): Use email instead of ID in the label

### DIFF
--- a/app/routes/settings+/profile.two-factor.verify.tsx
+++ b/app/routes/settings+/profile.two-factor.verify.tsx
@@ -39,10 +39,18 @@ export async function loader({ request }: DataFunctionArgs) {
 	if (!verification) {
 		return redirect('/settings/profile/two-factor')
 	}
+	const user = await prisma.user.findUnique({
+		where: { id: userId },
+		select: { email: true },
+	})
+	if (user == null) {
+		// This should not be possible
+		throw new Error(`user with ID "${userId}" is unknown`)
+	}
 	const issuer = new URL(getDomainUrl(request)).host
 	const otpUri = getTOTPAuthUri({
 		...verification,
-		accountName: userId,
+		accountName: user.email,
 		issuer,
 	})
 	const qrCode = await QRCode.toDataURL(otpUri)


### PR DESCRIPTION
#269
Make the request in the Authenticator app more meaningful by displaying the email address instead of `URL:userID` (not really known to the user). `URL:email`

## Test Plan

- [ ] Scan QR Code and see your email address as label.

## Checklist

- [x] Tests updated << n.a.
- [x] Docs updated << n.a.

