### PR TITLE
implement optimistic theme updates

### DIFF
--- a/app/routes/resources+/theme/index.tsx
+++ b/app/routes/resources+/theme/index.tsx
@@ -6,6 +6,8 @@ import * as React from 'react'
 import { safeRedirect } from 'remix-utils'
 import { z } from 'zod'
 import { ErrorList } from '~/components/forms.tsx'
+import { Icon } from '~/components/ui/icon.tsx'
+import { useHints } from '~/utils/client-hints.tsx'
 import { useRequestInfo } from '~/utils/request-info.ts'
 import {
 	commitSession,
@@ -13,7 +15,6 @@ import {
 	getSession,
 	setTheme,
 } from './theme-session.server.ts'
-import { Icon } from '~/components/ui/icon.tsx'
 
 const ROUTE_PATH = '/resources/theme'
 
@@ -126,14 +127,13 @@ export function ThemeSwitch({
  * has not set a preference.
  */
 export function useTheme() {
+	const hints = useHints()
 	const requestInfo = useRequestInfo()
 	const optimisticMode = useOptimisticThemeMode()
 	if (optimisticMode) {
-		return optimisticMode === 'system'
-			? requestInfo.hints.theme
-			: optimisticMode
+		return optimisticMode === 'system' ? hints.theme : optimisticMode
 	}
-	return requestInfo.session.theme ?? requestInfo.hints.theme
+	return requestInfo.session.theme ?? hints.theme
 }
 
 /**


### PR DESCRIPTION
Implements optimistic theme updates as discussed over at [Theme Switching Performance/UX #267](https://github.com/epicweb-dev/epic-stack/discussions/267)

## Test Plan

Test the theme switch button with network throttling on and make sure the theme updates without having to wait on the requests to finish.

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## GIFs
#### before
![before](https://github.com/epicweb-dev/epic-stack/assets/6809382/fb7757d6-b2ee-4f1b-83c4-a65d24349249)
#### after
![after](https://github.com/epicweb-dev/epic-stack/assets/6809382/8395e9e6-f28c-4668-be23-2c1f76b85c6c)


