### PR TITLE
Dialog overflows when the content does not fit

### DIFF
--- a/app/components/ui/dialog.tsx
+++ b/app/components/ui/dialog.tsx
@@ -40,7 +40,7 @@ const DialogContent = React.forwardRef<
 		<DialogPrimitive.Content
 			ref={ref}
 			className={cn(
-				'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full',
+				'fixed left-[50%] top-[50%] z-50 grid max-h-[90%] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full',
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
The dialog component overflows when the content doesn't fit in the viewport.
Reproduced on a 14-inch MacBook.

## Screenshots
Before fix
<img width="1011" alt="Screenshot 2023-07-09 at 14 18 06" src="https://github.com/epicweb-dev/epic-stack/assets/6989817/042e18d7-6cd6-4c08-8853-cce7d08348c1">

After fix
<img width="1010" alt="Screenshot 2023-07-09 at 14 18 58" src="https://github.com/epicweb-dev/epic-stack/assets/6989817/648129bd-43fd-42a7-8c8a-9f17ab6f563b">


