### PR TITLE
Fix image unloading flash in modal exit animation

### DIFF
--- a/app/routes/settings+/profile.photo.tsx
+++ b/app/routes/settings+/profile.photo.tsx
@@ -126,6 +126,7 @@ export async function action({ request }: DataFunctionArgs) {
 
 export default function PhotoChooserModal() {
 	const data = useLoaderData<typeof loader>() || {}
+	const [userImgId] = useState(data.user?.imageId);
 	const [newImageSrc, setNewImageSrc] = useState<string | null>(null)
 	const navigate = useNavigate()
 	const deleteImageFetcher = useFetcher<typeof deleteImageRoute.action>()
@@ -139,8 +140,8 @@ export default function PhotoChooserModal() {
 		},
 		shouldRevalidate: 'onBlur',
 	})
-	const [open, setOpen] = useState(true)
 
+	const [open, setOpen] = useState(true)
 	const deleteProfilePhotoFormId = 'delete-profile-photo'
 	const dismissModal = () => {
 		setOpen(false)
@@ -167,7 +168,7 @@ export default function PhotoChooserModal() {
 					<img
 						src={
 							newImageSrc ??
-							(data.user ? getUserImgSrc(data.user?.imageId) : '')
+							(userImgId ? getUserImgSrc(userImgId) : '')
 						}
 						className="h-64 w-64 rounded-full"
 						alt={data.user?.name ?? data.user?.username}

--- a/app/routes/settings+/profile.two-factor.verify.tsx
+++ b/app/routes/settings+/profile.two-factor.verify.tsx
@@ -3,6 +3,7 @@ import { getFieldsetConstraint, parse } from '@conform-to/zod'
 import { json, redirect, type DataFunctionArgs } from '@remix-run/node'
 import { useFetcher, useLoaderData } from '@remix-run/react'
 import * as QRCode from 'qrcode'
+import { useState } from 'react'
 import { z } from 'zod'
 import { Field } from '~/components/forms.tsx'
 import { StatusButton } from '~/components/ui/status-button.tsx'
@@ -144,6 +145,8 @@ export default function TwoFactorRoute() {
 	const data = useLoaderData<typeof loader>() || {}
 	const toggle2FAFetcher = useFetcher<typeof action>()
 
+	const [qrImgSrc] = useState(data?.qrCode)
+
 	const [form, fields] = useForm({
 		id: 'signup-form',
 		constraint: getFieldsetConstraint(verifySchema),
@@ -158,7 +161,7 @@ export default function TwoFactorRoute() {
 	return (
 		<div>
 			<div className="flex flex-col items-center gap-4">
-				<img alt="qr code" src={data?.qrCode} className="h-56 w-56" />
+				<img alt="qr code" src={qrImgSrc} className="h-56 w-56" />
 				<p>Scan this QR code with your authenticator app.</p>
 				<p className="text-sm">
 					If you cannot scan the QR code, you can manually add this account to


### PR DESCRIPTION
In the current implementation of modal exit animations in the `/settings/profile` route, images in the modals disappear or change to defaults during transition, producing an unpleasant 'flash' (as described and shown here: https://github.com/epicweb-dev/epic-stack/pull/246#issuecomment-1629266271).

This happens because the loader data used to derive the images is unloaded during client-side navigation from the modal's child route back to the parent route. A simple fix for this is to track the data used to derive the images as React state so that it is not affected by data unloading during navigation. This PR applies that fix to the user's profile image in `profile.photo.tsx` and the QR code image in `profile.two-factor.verify.ts`.


## Test Plan

- Check that the profile photo modal looks as expected when:
    - exiting the modal without changing the image
    - exiting the modal after deleting the image
    - exiting the modal after updating the image
- Check that the two factor verification modal looks as expected when verifying or cancelling

## Checklist

- No changes to tests or docs

## Screenshots (slowed down to make the change visible)

Before:
![before](https://github.com/epicweb-dev/epic-stack/assets/93843523/b63fc0a7-c42a-4b54-b8ce-f5bc53be3cfa)

After:
![after](https://github.com/epicweb-dev/epic-stack/assets/93843523/a4f139de-15e2-49c4-93f6-805b8bbb2d1d)

Hopefully this won't somehow introduce complications to work on #295 .
