### PR TITLE
Validate uniqueness of username before creating a user through signup

### DIFF
--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -83,22 +83,20 @@ export async function action({ request }: DataFunctionArgs) {
 
 	const formData = await request.formData()
 	const submission = await parse(formData, {
-		schema: () => {
-			return onboardingFormSchema.superRefine(async (data, ctx) => {
-				const existingUser = await prisma.user.findUnique({
-					where: { username: data.username },
-					select: { id: true },
-				})
-				if (existingUser) {
-					ctx.addIssue({
-						path: ['username'],
-						code: z.ZodIssueCode.custom,
-						message: 'A user already exists with this username',
-					})
-					return
-				}
+		schema: onboardingFormSchema.superRefine(async (data, ctx) => {
+			const existingUser = await prisma.user.findUnique({
+				where: { username: data.username },
+				select: { id: true },
 			})
-		},
+			if (existingUser) {
+				ctx.addIssue({
+					path: ['username'],
+					code: z.ZodIssueCode.custom,
+					message: 'A user already exists with this username',
+				})
+				return
+			}
+		}),
 		acceptMultipleErrors: () => true,
 		async: true,
 	})

--- a/app/routes/_auth+/signup/index.tsx
+++ b/app/routes/_auth+/signup/index.tsx
@@ -34,22 +34,20 @@ const signupSchema = z.object({
 export async function action({ request }: DataFunctionArgs) {
 	const formData = await request.formData()
 	const submission = await parse(formData, {
-		schema: () => {
-			return signupSchema.superRefine(async (data, ctx) => {
-				const existingUser = await prisma.user.findUnique({
-					where: { email: data.email },
-					select: { id: true },
-				})
-				if (existingUser) {
-					ctx.addIssue({
-						path: ['email'],
-						code: z.ZodIssueCode.custom,
-						message: 'A user already exists with this email',
-					})
-					return
-				}
+		schema: signupSchema.superRefine(async (data, ctx) => {
+			const existingUser = await prisma.user.findUnique({
+				where: { email: data.email },
+				select: { id: true },
 			})
-		},
+			if (existingUser) {
+				ctx.addIssue({
+					path: ['email'],
+					code: z.ZodIssueCode.custom,
+					message: 'A user already exists with this email',
+				})
+				return
+			}
+		}),
 		acceptMultipleErrors: () => true,
 		async: true,
 	})


### PR DESCRIPTION
In the current build, if a new user going through the sign in process on the onboarding page supplies a username that is already in use, the onboarding action attempts to create a new user, violating the Prisma schema's uniqueness constraint. This throws an exception that goes all the way to the main error boundary.

This PR changes the behavior of the onboarding page so that submitting a non-unique username is treated as a form validation error instead, using the same kind of check used in `_auth+/signup/index.tsx` to verify the uniqueness of emails.

## Test Plan

- Check that the UX of the onboarding experience is as expected when onboarding with duplicate and non-duplicate usernames

## Checklist

No changes to tests or docs

## Screenshots

Before:
![before](https://github.com/epicweb-dev/epic-stack/assets/93843523/f55cd2cc-92d1-4a27-be8b-26af38a5fb87)

After:
![after](https://github.com/epicweb-dev/epic-stack/assets/93843523/6a19f660-03a6-4b56-8db7-a384f6641b07)

