### PR TITLE
Explain cookie expires

### DIFF
--- a/app/routes/resources+/login.tsx
+++ b/app/routes/resources+/login.tsx
@@ -88,6 +88,7 @@ export async function action({ request }: DataFunctionArgs) {
 	const responseInit = {
 		headers: {
 			'Set-Cookie': await commitSession(cookieSession, {
+				// Cookies with no expiration are cleared when the tab/window closes
 				expires: remember ? session.expirationDate : undefined,
 			}),
 		},


### PR DESCRIPTION
If you assume a cookie with no `expires` field doesn't expire, this remember me checkbox appears to be backwards, so I've added a comment explaining why it does work