### PR TITLE
Update Dockerfile to add patch directory to deps

### DIFF
--- a/other/Dockerfile
+++ b/other/Dockerfile
@@ -15,6 +15,7 @@ FROM base as deps
 WORKDIR /myapp
 
 ADD package.json package-lock.json .npmrc ./
+ADD ./other/patches ./other/patches
 RUN npm install --include=dev
 
 # Setup production node_modules


### PR DESCRIPTION
It seems that in the current Docker image build process, the `other/patches` directory is not included in the deps layer, so patches that are applied by the `patch-package` npm postinstall script in the development environment do not end up being applied in deployments. 

This doesn't have much impact on the app right now because the only patch in the current build is for something in the dev environment, but it may have meant, for example, that in earlier builds, CSP might have been broken in deployment. It also ends up being a 'gotcha' for people using epic-stack who add patches for whatever reason.

This PR simply adds the patch directory to the deps layer so that the `node_modules` that gets copied to the deployed image has patches applied to it.

## Test Plan

- Add any patch to a dependency and verify that it is:
    - Not applied by the build process prior to this change
    - Applied by the build process after this change

## Checklist

No changes to tests or docs

For additional context, see the related Discord [discussion thread](https://discord.com/channels/715220730605731931/1130543194082394272)