### PR TITLE
fix - upload profile image without JS

### DIFF
--- a/app/routes/settings+/profile.photo.tsx
+++ b/app/routes/settings+/profile.photo.tsx
@@ -182,6 +182,9 @@ export default function PhotoRoute() {
 							</label>
 						</Button>
 
+						{/* This is here for progressive enhancement. If the client doesn't
+						hydrate (or hasn't yet) this button will be available to submit the
+						selected photo. */}
 						<ServerOnly>
 							{() => (
 								<Button type="submit" className="server-only">

--- a/app/routes/settings+/profile.photo.tsx
+++ b/app/routes/settings+/profile.photo.tsx
@@ -14,6 +14,7 @@ import {
 	useLoaderData,
 } from '@remix-run/react'
 import { useState } from 'react'
+import { ServerOnly } from 'remix-utils'
 import { z } from 'zod'
 import { ErrorList } from '~/components/forms.tsx'
 import { Button } from '~/components/ui/button.tsx'
@@ -153,7 +154,7 @@ export default function PhotoRoute() {
 				<input
 					{...conform.input(photoFile, { type: 'file' })}
 					accept="image/*"
-					className="sr-only"
+					className="sr-only peer"
 					tabIndex={newImageSrc ? -1 : 0}
 					onChange={e => {
 						const file = e.currentTarget.files?.[0]
@@ -174,12 +175,18 @@ export default function PhotoRoute() {
 						</Button>
 					</div>
 				) : (
-					<div className="flex gap-4">
+					<div className="flex gap-4 peer-invalid:[&>.server-only[type='submit']]:hidden">
 						<Button asChild className="cursor-pointer">
 							<label htmlFor={photoFile.id}>
 								<Icon name="pencil-1">Change</Icon>
 							</label>
 						</Button>
+            
+            <ServerOnly>
+              {() => (
+                <Button type="submit" className="server-only">Save Photo</Button>
+              )}
+            </ServerOnly>
 						{data.user?.imageId ? (
 							<Button
 								variant="destructive"

--- a/app/routes/settings+/profile.photo.tsx
+++ b/app/routes/settings+/profile.photo.tsx
@@ -154,7 +154,7 @@ export default function PhotoRoute() {
 				<input
 					{...conform.input(photoFile, { type: 'file' })}
 					accept="image/*"
-					className="sr-only peer"
+					className="peer sr-only"
 					tabIndex={newImageSrc ? -1 : 0}
 					onChange={e => {
 						const file = e.currentTarget.files?.[0]
@@ -181,12 +181,14 @@ export default function PhotoRoute() {
 								<Icon name="pencil-1">Change</Icon>
 							</label>
 						</Button>
-            
-            <ServerOnly>
-              {() => (
-                <Button type="submit" className="server-only">Save Photo</Button>
-              )}
-            </ServerOnly>
+
+						<ServerOnly>
+							{() => (
+								<Button type="submit" className="server-only">
+									Save Photo
+								</Button>
+							)}
+						</ServerOnly>
 						{data.user?.imageId ? (
 							<Button
 								variant="destructive"


### PR DESCRIPTION
This solution enables uploading a profile image with JS disabled.
The issue is, that without JS the Save button won't show up, as it is activated using client-side JS.

The proposed solution uses the peer class on the input element and hides a server-only submit as long as the input field is invalid. `peer-invalid:[&>.server-only[type='submit']]:hidden`

The complete discussion can be found here:
https://github.com/epicweb-dev/epic-stack/issues/311

## Test Plan

- Disable JS
- Add an image using the file input
- The "Save Photo" Button shows up
- Hit "Save Photo"

## Checklist

Do we add tests for nojs implementations?

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

Before:
![kodybefore](https://github.com/epicweb-dev/epic-stack/assets/25255815/7567066f-c172-4e0b-8055-fa1a32a6d5a0)

After:
![kody](https://github.com/epicweb-dev/epic-stack/assets/25255815/f6e6c9cf-f27d-43a8-b2e8-1480eb7c5155)

