### PR TITLE
fix - remove profile picture without JS

### DIFF
--- a/app/routes/settings+/profile.photo.tsx
+++ b/app/routes/settings+/profile.photo.tsx
@@ -225,6 +225,9 @@ export default function PhotoRoute() {
 				action={deleteImageRoute.ROUTE_PATH}
 				onSubmit={() => setNewImageSrc(null)}
 			>
+				<ServerOnly>
+					{() => <input name="serverOnly" type="hidden" value="true" />}
+				</ServerOnly>
 				<input name="intent" type="hidden" value="submit" />
 				<input name="imageId" type="hidden" value={data.user?.imageId ?? ''} />
 			</deleteImageFetcher.Form>

--- a/app/routes/settings+/profile.photo.tsx
+++ b/app/routes/settings+/profile.photo.tsx
@@ -195,12 +195,7 @@ export default function PhotoRoute() {
 						selected photo. */}
 						<ServerOnly>
 							{() => (
-								<Button
-									type="submit"
-									name="redirectTo"
-									value="/settings/profile/photo"
-									className="server-only"
-								>
+								<Button type="submit" className="server-only">
 									Save Photo
 								</Button>
 							)}
@@ -231,7 +226,13 @@ export default function PhotoRoute() {
 				onSubmit={() => setNewImageSrc(null)}
 			>
 				<ServerOnly>
-					{() => <input name="serverOnly" type="hidden" value="true" />}
+					{() => (
+						<input
+							name="redirectTo"
+							value="/settings/profile/photo"
+							type="hidden"
+						/>
+					)}
 				</ServerOnly>
 				<input name="intent" type="hidden" value="submit" />
 				<input name="imageId" type="hidden" value={data.user?.imageId ?? ''} />

--- a/app/routes/settings+/profile.photo.tsx
+++ b/app/routes/settings+/profile.photo.tsx
@@ -195,7 +195,12 @@ export default function PhotoRoute() {
 						selected photo. */}
 						<ServerOnly>
 							{() => (
-								<Button type="submit" className="server-only">
+								<Button
+									type="submit"
+									name="redirectTo"
+									value="/settings/profile/photo"
+									className="server-only"
+								>
 									Save Photo
 								</Button>
 							)}


### PR DESCRIPTION
Deleting a profile picture without JS has a bad UX, as the action doesn't redirect. This PR addresses this issue by introducing a new hidden property on form submission.

Issue: https://github.com/epicweb-dev/epic-stack/issues/313

## Screenshots

Old behavior without JS:
![image](https://github.com/epicweb-dev/epic-stack/assets/25255815/df198acf-81e0-4355-932e-cbef56290d0a)

Behavior with JS:
![deletebefore](https://github.com/epicweb-dev/epic-stack/assets/25255815/4f8a9d09-b748-4f6c-bc51-7babdba6e404)

New behavior without JS:
![deleteafter](https://github.com/epicweb-dev/epic-stack/assets/25255815/6a3a2cd8-435e-42b6-a44c-64af7a74661e)
