### PR TITLE
fix: export litefs-js from server file to prevent fs polyfill

### DIFF
--- a/app/routes/admin+/cache.tsx
+++ b/app/routes/admin+/cache.tsx
@@ -7,8 +7,11 @@ import {
 	useSearchParams,
 	useSubmit,
 } from '@remix-run/react'
-import { getAllInstances, getInstanceInfo } from 'litefs-js'
-import { ensureInstance } from 'litefs-js/remix.js'
+import {
+	getAllInstances,
+	getInstanceInfo,
+	ensureInstance,
+} from '~/utils/litefs.server.ts'
 import * as React from 'react'
 import { Field } from '~/components/forms.tsx'
 import { Spacer } from '~/components/spacer.tsx'

--- a/app/utils/cache.server.ts
+++ b/app/utils/cache.server.ts
@@ -10,7 +10,7 @@ import {
 	type CachifiedOptions,
 } from 'cachified'
 import fs from 'fs'
-import { getInstanceInfo, getInstanceInfoSync } from 'litefs-js'
+import { getInstanceInfo, getInstanceInfoSync } from '~/utils/litefs.server.ts'
 import { LRUCache } from 'lru-cache'
 import { z } from 'zod'
 import { updatePrimaryCacheValue } from '~/routes/admin+/cache_.sqlite.tsx'

--- a/app/utils/litefs.server.ts
+++ b/app/utils/litefs.server.ts
@@ -1,0 +1,2 @@
+export * from 'litefs-js'
+export * from 'litefs-js/remix.js'

--- a/app/utils/litefs.server.ts
+++ b/app/utils/litefs.server.ts
@@ -1,2 +1,5 @@
+// litefs-js should be used server-side only. It imports `fs` which results in Remix
+// including a big polyfill. So we put the import in a `.server.ts` file to avoid that
+// polyfill from being included. https://github.com/epicweb-dev/epic-stack/pull/331
 export * from 'litefs-js'
 export * from 'litefs-js/remix.js'


### PR DESCRIPTION
Remix v1.19.0 now generates esbuild manifest for bundle analysis. The package `litefs-js` has a side-effect where it imports node fs module resulting in a polyfill being generated for a client bundle.

This commit exports litefs-js from a *.server file to ensure that the polyfill is not bundled.

## Before fix

### Bundle size 2.1 mb, 266 kb from polyfill in routes/admin+cache
<img width="1155" alt="image" src="https://github.com/epicweb-dev/epic-stack/assets/47168/f84f992e-f494-43b1-9317-d99f5e5256ed">

<img width="1027" alt="image" src="https://github.com/epicweb-dev/epic-stack/assets/47168/ed7661b8-8823-44cc-81f2-565bf30e3b0a">

## After fix

### Bundle size 1.8 mb (no more polyfill)
<img width="1052" alt="image" src="https://github.com/epicweb-dev/epic-stack/assets/47168/6743d720-d6ec-4c29-bf9d-2b7cd52f78c8">
