### PR TITLE
fix: issue where user could not edit the password and user name at same time. close #335

### DIFF
--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -11,7 +11,7 @@ import {
 	authenticator,
 	getPasswordHash,
 	requireUserId,
-	verifyLogin,
+	verifyUserPassword,
 } from '~/utils/auth.server.ts'
 import { prisma } from '~/utils/db.server.ts'
 import { getUserImgSrc, useIsSubmitting } from '~/utils/misc.ts'
@@ -70,7 +70,7 @@ export async function action({ request }: DataFunctionArgs) {
 					})
 				}
 				if (currentPassword && newPassword) {
-					const user = await verifyLogin(username, currentPassword)
+					const user = await verifyUserPassword({ id: userId }, currentPassword)
 					if (!user) {
 						ctx.addIssue({
 							path: ['currentPassword'],

--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -26,7 +26,7 @@ authenticator.use(
 		invariant(typeof password === 'string', 'password must be a string')
 		invariant(password.length > 0, 'password must not be empty')
 
-		const user = await verifyLogin(username, password)
+		const user = await verifyUserPassword({ username }, password)
 		if (!user) {
 			throw new Error('Invalid username or password')
 		}
@@ -151,12 +151,12 @@ export async function getPasswordHash(password: string) {
 	return hash
 }
 
-export async function verifyLogin(
-	username: User['username'],
+export async function verifyUserPassword(
+	where: Pick<User, 'username'> | Pick<User, 'id'>,
 	password: Password['hash'],
 ) {
 	const userWithPassword = await prisma.user.findUnique({
-		where: { username },
+		where,
 		select: { id: true, password: { select: { hash: true } } },
 	})
 

--- a/tests/e2e/settings-profile.test.ts
+++ b/tests/e2e/settings-profile.test.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { expect, insertNewUser, test } from '../playwright-utils.ts'
 import { createUser } from '../../tests/db-utils.ts'
-import { verifyLogin } from '~/utils/auth.server.ts'
+import { verifyUserPassword } from '~/utils/auth.server.ts'
 
 test('Users can update their basic info', async ({ login, page }) => {
 	await login()
@@ -41,12 +41,13 @@ test('Users can update their password', async ({ login, page }) => {
 
 	await expect(page).toHaveURL(`/users/${user.username}`)
 
+	const { username } = user
 	expect(
-		await verifyLogin(user.username, oldPassword),
+		await verifyUserPassword({ username }, oldPassword),
 		'Old password still works',
 	).toEqual(null)
 	expect(
-		await verifyLogin(user.username, newPassword),
+		await verifyUserPassword({ username }, newPassword),
 		'New password does not work',
 	).toEqual({ id: user.id })
 })


### PR DESCRIPTION
We were checking the user's username based on the user input to validade their current password. This PR changes it to check the user's current password based on the userId.

## Test Plan

Go tot the settings page and try to change your username and password at same time

## Checklist

- [x] Tests updated
<!-- - [ ] Docs updated -->

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
