### PR TITLE
use zod to parse environment variables

### DIFF
--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -1,28 +1,34 @@
-import { invariant } from './misc.ts'
+import { z } from 'zod'
 
-const requiredServerEnvs = [
-	'NODE_ENV',
-	'DATABASE_PATH',
-	'DATABASE_URL',
-	'SESSION_SECRET',
-	'INTERNAL_COMMAND_TOKEN',
-	'CACHE_DATABASE_PATH',
-	// If you plan to use Resend, uncomment this line
-	// 'RESEND_API_KEY',
+const schema = z.object({
+	NODE_ENV: z.enum(['production', 'development', 'test'] as const),
+	DATABASE_PATH: z.string(),
+	DATABASE_URL: z.string(),
+	SESSION_SECRET: z.string(),
+	INTERNAL_COMMAND_TOKEN: z.string(),
+	CACHE_DATABASE_PATH: z.string(),
 	// If you plan on using Sentry, uncomment this line
-	// 'SENTRY_DSN',
-] as const
+	// SENTRY_DSN: z.string(),
+	// If you plan to use Resend, uncomment this line
+	// RESEND_API_KEY: z.string(),
+})
 
 declare global {
 	namespace NodeJS {
-		interface ProcessEnv
-			extends Record<(typeof requiredServerEnvs)[number], string> {}
+		interface ProcessEnv extends z.infer<typeof schema> {}
 	}
 }
 
 export function init() {
-	for (const env of requiredServerEnvs) {
-		invariant(process.env[env], `${env} is required`)
+	const parsed = schema.safeParse(process.env)
+
+	if (parsed.success === false) {
+		console.error(
+			'❌ Invalid environment variables:',
+			parsed.error.flatten().fieldErrors,
+		)
+
+		throw new Error('Invalid envirmonment variables')
 	}
 }
 
@@ -36,8 +42,6 @@ export function init() {
  * @returns all public ENV variables
  */
 export function getEnv() {
-	invariant(process.env.NODE_ENV, 'NODE_ENV should be defined')
-
 	return {
 		MODE: process.env.NODE_ENV,
 		SENTRY_DSN: process.env.SENTRY_DSN,


### PR DESCRIPTION
Use zod to create and parse a schema that represents the required server environment variables. The main benefit here is that the  schema can explicitly declare and validate complex types for env variables and potentially coerce strings into the appropriate types where needed(such as numbers and enum values.)
