### PR TITLE
Fix css links issues due to RDT

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -62,9 +62,9 @@ export const links: LinksFunction = () => {
 		{ rel: 'preload', href: fontStylestylesheetUrl, as: 'style' },
 		{ rel: 'preload', href: tailwindStylesheetUrl, as: 'style' },
 		cssBundleHref ? { rel: 'preload', href: cssBundleHref, as: 'style' } : null,
-		...(rdtStylesheetUrl && process.env.NODE_ENV === 'development'
-			? [{ rel: 'preload', as: 'style', href: rdtStylesheetUrl }]
-			: []),
+		rdtStylesheetUrl && process.env.NODE_ENV === 'development'
+			? { rel: 'preload', href: rdtStylesheetUrl, as: 'style' }
+			: null,
 		{ rel: 'mask-icon', href: '/favicons/mask-icon.svg' },
 		{
 			rel: 'alternate icon',
@@ -77,14 +77,14 @@ export const links: LinksFunction = () => {
 			href: '/site.webmanifest',
 			crossOrigin: 'use-credentials',
 		} as const, // necessary to make typescript happy
+		//These should match the css preloads above to avoid css as render blocking resource
 		{ rel: 'icon', type: 'image/svg+xml', href: '/favicons/favicon.svg' },
 		{ rel: 'stylesheet', href: fontStylestylesheetUrl },
 		{ rel: 'stylesheet', href: tailwindStylesheetUrl },
-		{ rel: 'stylesheet', href: rdtStylesheetUrl },
-		...(rdtStylesheetUrl && process.env.NODE_ENV === 'development'
-			? [{ rel: 'stylesheet', href: rdtStylesheetUrl }]
-			: []),
 		cssBundleHref ? { rel: 'stylesheet', href: cssBundleHref } : null,
+		rdtStylesheetUrl && process.env.NODE_ENV === 'development'
+			? { rel: 'stylesheet', href: rdtStylesheetUrl }
+			: null,
 	].filter(Boolean)
 }
 


### PR DESCRIPTION
RDT css was accidentally leaked into the production build, making it a render blocking resource and delaying load time:

![image](https://github.com/epicweb-dev/epic-stack/assets/84349818/e24a4a1e-51a2-4791-9b62-1e4533fcc278)

https://www.webpagetest.org/video/compare.php?tests=230725_AiDcJA_B64-r:2-c:0

## Test Plan

As this is a browser behavior, I don't believe there is a test for this.

## Checklist

- [x] Tests updated
- [x] Docs updated

## Screenshots

### Before
![image](https://github.com/epicweb-dev/epic-stack/assets/84349818/7aab7cb3-7dc8-4013-8d6a-1d5ad52eb800)

### After
![image](https://github.com/epicweb-dev/epic-stack/assets/84349818/9c2cac0d-94cb-40ab-8e25-3c100df0a8e5)
