### PR TITLE
Improve detection of new svg icons #349

### DIFF
--- a/other/build-icons.ts
+++ b/other/build-icons.ts
@@ -36,8 +36,8 @@ async function generateIconFiles() {
 
 	const iconNames = files.map(file => iconName(file))
 
-	const spriteUpToDate = iconNames.every(name => currentSprite.includes(name))
-	const typesUpToDate = iconNames.every(name => currentTypes.includes(name))
+	const spriteUpToDate = iconNames.every(name => currentSprite.includes(`id=${name}`))
+	const typesUpToDate = iconNames.every(name => currentTypes.includes(`"${name}"`))
 
 	if (spriteUpToDate && typesUpToDate) {
 		console.log(`Icons are up to date`)


### PR DESCRIPTION
Improve the check if an svg icon is already contained in the spritesvg/name.d.ts by making sure there is no icon with the same name but a pre- or suffix. 

## Test Plan

-

## Checklist

- [ ] Tests updated
- [ ] Docs updated

