### PR TITLE
Add 'css.lint.unknownAtRules' setting to ignore unknown @-rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
     "stream/consumers",
     "node:stream/consumers"
   ],
-  "tailwindCSS.experimental.classRegex": [["cn\\(([^)]*)\\)"]]
+  "tailwindCSS.experimental.classRegex": [["cn\\(([^)]*)\\)"]],
+  "css.lint.unknownAtRules": "ignore",
 }


### PR DESCRIPTION
This PR adds the following configuration to the `settings.json` file:

"css.lint.unknownAtRules": "ignore",

By setting `css.lint.unknownAtRules` to "ignore," we are instructing the CSS linter to ignore any unknown @-rules.
