### PR TITLE
Clarify location of SENTRY_AUTH_TOKEN in Sentry UI

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -26,7 +26,7 @@ Once you see the onboarding page which has the DSN, copy that somewhere (this
 becomes `SENTRY_DSN`). Then click
 [this](https://sentry.io/orgredirect/settings/:orgslug/developer-settings/new-internal/)
 to create an internal integration. Give it a name and add the scope for
-`Releases:Admin`. Press Save, find the auth token at the bottom of the page, and
+`Releases:Admin`. Press Save, find the auth token at the bottom of the page under "Tokens", and
 copy that to secure location (this becomes `SENTRY_AUTH_TOKEN`). Then vist the
 organization settings page and copy that organization slug (`SENTRY_ORG_SLUG`).
 


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
Minimize Setup Friction by clarifying which token to select as the `SENTRY_AUTH_TOKEN`.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->
N/A

## Checklist

- [ ] Tests updated
- [x] Docs updated

## Description
Prevent ambiguity between the `SENTRY_AUTH_TOKEN` at the bottom of the page and the `Client Secret` located at the very bottom of the page which looks like a token without being the correct one. 

I spent a while debugging why the deployment failed before realizing that I had selected the wrong token from Sentry. Having fly.io managing secrets in the Github Action was new to me, so I wasted time checking if it had to be added as Github secrets before realizing my mistake. I hope this small clarification will help prevent future users from making the same mistake.  

## Screenshots
**From Sentry:**
<img width="682" alt="Screenshot 2023-08-04 at 19 37 56" src="https://github.com/epicweb-dev/epic-stack/assets/6596033/2c553a5b-cbba-4db5-ace8-bb8afc7a15ee">

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
