### PR TITLE
move hsl values to tailwind.config for editor color previews

### DIFF
--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -5,77 +5,77 @@
 @layer base {
 	:root {
 		--font-sans: Nunito Sans, Nunito Sans Fallback;
-		/* --font-mono: here if you got it... */
+		/* --font-mono: hsl(here if you got it... */
 
 		/* prefixed with foreground because it should look good on the background */
-		--foreground-danger: 345 82.7% 40.8%;
+		--foreground-danger: hsl(345 82.7% 40.8%);
 
-		--background: 0 0% 100%;
-		--foreground: 222.2 84% 4.9%;
+		--background: hsl(0 0% 100%);
+		--foreground: hsl(222.2 84% 4.9%);
 
-		--muted: 210 40% 96.1%;
-		--muted-foreground: 215.4 16.3% 46.9%;
+		--muted: hsl(210 40% 96.1%);
+		--muted-foreground: hsl(215.4 16.3% 46.9%);
 
-		--popover: 0 0% 100%;
-		--popover-foreground: 222.2 84% 4.9%;
+		--popover: hsl(0 0% 100%);
+		--popover-foreground: hsl(222.2 84% 4.9%);
 
-		--card: 0 0% 100%;
-		--card-foreground: 222.2 84% 4.9%;
+		--card: hsl(0 0% 100%);
+		--card-foreground: hsl(222.2 84% 4.9%);
 
-		--border: 214.3 31.8% 91.4%;
-		--input: 214.3 31.8% 91.4%;
-		--input-invalid: 0 84.2% 60.2%;
+		--border: hsl(214.3 31.8% 91.4%);
+		--input: hsl(214.3 31.8% 91.4%);
+		--input-invalid: hsl(0 84.2% 60.2%);
 
-		--primary: 222.2 47.4% 11.2%;
-		--primary-foreground: 210 40% 98%;
+		--primary: hsl(222.2 47.4% 11.2%);
+		--primary-foreground: hsl(210 40% 98%);
 
-		--secondary: 210 40% 96.1%;
-		--secondary-foreground: 222.2 47.4% 11.2%;
+		--secondary: hsl(210 40% 96.1%);
+		--secondary-foreground: hsl(222.2 47.4% 11.2%);
 
-		--accent: 210 40% 90%;
-		--accent-foreground: 222.2 47.4% 11.2%;
+		--accent: hsl(210 40% 90%);
+		--accent-foreground: hsl(222.2 47.4% 11.2%);
 
-		--destructive: 0 84.2% 60.2%;
-		--destructive-foreground: 210 40% 98%;
+		--destructive: hsl(0 84.2% 60.2%);
+		--destructive-foreground: hsl(210 40% 98%);
 
-		--ring: 215 20.2% 65.1%;
+		--ring: hsl(215 20.2% 65.1%);
 
 		--radius: 0.5rem;
 	}
 
 	.dark {
-		--background: 222.2 84% 4.9%;
-		--foreground: 210 40% 98%;
+		--background: hsl(222.2 84% 4.9%);
+		--foreground: hsl(210 40% 98%);
 
 		/* prefixed with foreground because it should look good on the background */
-		--foreground-danger: -4 84% 60%;
+		--foreground-danger: hsl(-4 84% 60%);
 
-		--muted: 217.2 32.6% 17.5%;
-		--muted-foreground: 215 20.2% 65.1%;
+		--muted: hsl(217.2 32.6% 17.5%);
+		--muted-foreground: hsl(215 20.2% 65.1%);
 
-		--popover: 222.2 84% 4.9%;
-		--popover-foreground: 210 40% 98%;
+		--popover: hsl(222.2 84% 4.9%);
+		--popover-foreground: hsl(210 40% 98%);
 
-		--card: 222.2 84% 4.9%;
-		--card-foreground: 210 40% 98%;
+		--card: hsl(222.2 84% 4.9%);
+		--card-foreground: hsl(210 40% 98%);
 
-		--border: 217.2 32.6% 17.5%;
-		--input: 217.2 32.6% 17.5%;
-		--input-invalid: 0 62.8% 30.6%;
+		--border: hsl(217.2 32.6% 17.5%);
+		--input: hsl(217.2 32.6% 17.5%);
+		--input-invalid: hsl(0 62.8% 30.6%);
 
-		--primary: 210 40% 98%;
-		--primary-foreground: 222.2 47.4% 11.2%;
+		--primary: hsl(210 40% 98%);
+		--primary-foreground: hsl(222.2 47.4% 11.2%);
 
-		--secondary: 217.2 32.6% 17.5%;
-		--secondary-foreground: 210 40% 98%;
+		--secondary: hsl(217.2 32.6% 17.5%);
+		--secondary-foreground: hsl(210 40% 98%);
 
-		--accent: 217.2 32.6% 10%;
-		--accent-foreground: 210 40% 98%;
+		--accent: hsl(217.2 32.6% 10%);
+		--accent-foreground: hsl(210 40% 98%);
 
-		--destructive: 0 62.8% 30.6%;
-		--destructive-foreground: 0 85.7% 97.3%;
+		--destructive: hsl(0 62.8% 30.6%);
+		--destructive-foreground: hsl(0 85.7% 97.3%);
 
-		--ring: 217.2 32.6% 17.5%;
+		--ring: hsl(217.2 32.6% 17.5%);
 	}
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,47 +16,47 @@ export default {
 		},
 		extend: {
 			colors: {
-				border: 'hsl(var(--border))',
+				border: 'var(--border)',
 				input: {
-					DEFAULT: 'hsl(var(--input))',
-					invalid: 'hsl(var(--input-invalid))',
+					DEFAULT: 'var(--input)',
+					invalid: 'var(--input-invalid)',
 				},
 				ring: {
-					DEFAULT: 'hsl(var(--ring))',
-					invalid: 'hsl(var(--foreground-danger))',
+					DEFAULT: 'var(--ring)',
+					invalid: 'var(--foreground-danger)',
 				},
-				background: 'hsl(var(--background))',
+				background: 'var(--background)',
 				foreground: {
-					DEFAULT: 'hsl(var(--foreground))',
-					danger: 'hsl(var(--foreground-danger))',
+					DEFAULT: 'var(--foreground)',
+					danger: 'var(--foreground-danger)',
 				},
 				primary: {
-					DEFAULT: 'hsl(var(--primary))',
-					foreground: 'hsl(var(--primary-foreground))',
+					DEFAULT: 'var(--primary)',
+					foreground: 'var(--primary-foreground)',
 				},
 				secondary: {
-					DEFAULT: 'hsl(var(--secondary))',
-					foreground: 'hsl(var(--secondary-foreground))',
+					DEFAULT: 'var(--secondary)',
+					foreground: 'var(--secondary-foreground)',
 				},
 				destructive: {
-					DEFAULT: 'hsl(var(--destructive))',
-					foreground: 'hsl(var(--destructive-foreground))',
+					DEFAULT: 'var(--destructive)',
+					foreground: 'var(--destructive-foreground)',
 				},
 				muted: {
-					DEFAULT: 'hsl(var(--muted))',
-					foreground: 'hsl(var(--muted-foreground))',
+					DEFAULT: 'var(--muted)',
+					foreground: 'var(--muted-foreground)',
 				},
 				accent: {
-					DEFAULT: 'hsl(var(--accent))',
-					foreground: 'hsl(var(--accent-foreground))',
+					DEFAULT: 'var(--accent)',
+					foreground: 'var(--accent-foreground)',
 				},
 				popover: {
-					DEFAULT: 'hsl(var(--popover))',
-					foreground: 'hsl(var(--popover-foreground))',
+					DEFAULT: 'var(--popover)',
+					foreground: 'var(--popover-foreground)',
 				},
 				card: {
-					DEFAULT: 'hsl(var(--card))',
-					foreground: 'hsl(var(--card-foreground))',
+					DEFAULT: 'var(--card)',
+					foreground: 'var(--card-foreground)',
 				},
 			},
 			borderRadius: {


### PR DESCRIPTION
<img width="607" alt="image" src="https://github.com/epicweb-dev/epic-stack/assets/1377089/dd1ca448-9579-49bd-acc7-924057a67276">

It's nice to have a color preview and picker in editors that support it