### PR TITLE
fix: add other/patches directory for dockerfile

### DIFF
--- a/other/Dockerfile
+++ b/other/Dockerfile
@@ -15,7 +15,6 @@ FROM base as deps
 WORKDIR /myapp
 
 ADD package.json package-lock.json .npmrc ./
-ADD ./other/patches ./other/patches
 RUN npm install --include=dev
 
 # Setup production node_modules


### PR DESCRIPTION
seems like following the last commit, the `/other/patches` directory has been removed which is still trying to be copy by the `Dockerfile` which break deployment on new project init with the epic stack

i thought about removing the line from the Dockerfile but choose for adding the empty `/other/patches` directory for future patches instead.

## Test Plan

None

## Checklist

- [X] Tests updated
- [X] Docs updated

## Error log

```
==> Verifying app config
Validating /Users/xstevenyung/Code/simplefeedback/fly.toml
Platform: machines
✓ Configuration is valid
--> Verified app config
==> Building image
Remote builder fly-builder-wandering-voice-8657 ready
==> Building image with Docker
--> docker host: 20.10.12 linux x86_64
[+] Building 0.7s (10/32)                                                                                                            
 => [internal] load build definition from Dockerfile                                                                            0.0s
 => => transferring dockerfile: 69B                                                                                             0.0s
 => [internal] load .dockerignore                                                                                               0.0s
 => => transferring context: 72B                                                                                                0.0s
 => [internal] load metadata for docker.io/library/node:18-bookworm-slim                                                        0.4s
 => CANCELED FROM docker.io/flyio/litefs:0.5.1                                                                                  0.2s
 => => resolve docker.io/flyio/litefs:0.5.1                                                                                     0.2s
 => [internal] load build context                                                                                               0.2s
 => => transferring context: 26.61kB                                                                                            0.2s
 => CANCELED [base 1/2] FROM docker.io/library/node:18-bookworm-slim@sha256:a0cca98f2896135d4c0386922211c1f90f98f27a58b8f2c078  0.2s
 => => resolve docker.io/library/node:18-bookworm-slim@sha256:a0cca98f2896135d4c0386922211c1f90f98f27a58b8f2c07850d0fbe1c2104e  0.0s
 => => sha256:85f19dcf293f90eea5d945e8d9326915e64dafd19134990e952dc139e93334be 2.10MB / 46.23MB                                 0.2s
 => => sha256:fda13199b871a106af2b82d3f1a364db4c7e9013f3ddd4cfa09f06b826a2e069 2.74MB / 2.74MB                                  0.1s
 => => sha256:c66f790f220d62b4670d0bafc1a78599535d75eedc08014206064cec045393a0 449B / 449B                                      0.0s
 => => sha256:a0cca98f2896135d4c0386922211c1f90f98f27a58b8f2c07850d0fbe1c2104e 1.21kB / 1.21kB                                  0.0s
 => => sha256:479c8ad8e42c5a6faae5f6b68422752d6d04572e342e5d57294491b583905416 1.37kB / 1.37kB                                  0.0s
 => => sha256:bb7a9e2a4026061db79775dc46a3c4bf4c99338153f4980b6ba13c3ff2b2dad7 7.02kB / 7.02kB                                  0.0s
 => => sha256:648e0aadf75ac2ef63c5390adc6dc14fde37a5ad88c2870ea604df0a9c0eb4e5 6.29MB / 29.12MB                                 0.2s
 => => sha256:41c739c16d9c8230e3d4ada4de98c921685be379301d557749f0bea99febd5d6 3.36kB / 3.36kB                                  0.0s
 => CACHED [base 2/2] RUN apt-get update && apt-get install -y fuse3 openssl sqlite3 ca-certificates                            0.0s
 => CACHED [production-deps 1/4] WORKDIR /myapp                                                                                 0.0s
 => CACHED [deps 2/4] ADD package.json package-lock.json .npmrc ./                                                              0.0s
 => ERROR [deps 3/4] ADD ./other/patches ./other/patches                                                                        0.0s
------
 > [deps 3/4] ADD ./other/patches ./other/patches:
------
Error: failed to fetch an image or build from source: error building: failed to solve: failed to compute cache key: "/other/patches" not found: not found
```

