### PR TITLE
fix: development build reloading

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -34,7 +34,7 @@ const createRequestHandler = wrapExpressCreateRequestHandler(
 	_createRequestHandler,
 )
 
-const BUILD_PATH = '#build/index.js'
+const BUILD_PATH = '../build/index.js'
 
 const build = remixBuild as unknown as ServerBuild
 let devBuild = build


### PR DESCRIPTION
Closes: https://github.com/epicweb-dev/epic-stack/issues/391

The alias import doesn't work here, changing it back to a relative import fixes the development build reload.

## Test Plan

I manually confirmed that making a change resulted in the page live-reloading in development mode.

## Checklist

- [ ] Tests updated
- [ ] Docs updated
