### PR TITLE
remove unused const `ROUTE_PATH`

### DIFF
--- a/app/routes/resources+/download-user-data.tsx
+++ b/app/routes/resources+/download-user-data.tsx
@@ -3,8 +3,6 @@ import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { getDomainUrl } from '#app/utils/misc.tsx'
 
-export const ROUTE_PATH = '/resources/download-user-data'
-
 export async function loader({ request }: DataFunctionArgs) {
 	const userId = await requireUserId(request)
 	const user = await prisma.user.findUniqueOrThrow({


### PR DESCRIPTION
Hi!

While reviewing the code, I came across this const whose purpose wasn't clear to me. It's possible that it's related to a feature I'm unfamiliar with.

I've removed it in this PR. Feel free to merge if appropriate. If the const is essential for some functionality, I'd love to know what it's for! 

Thank you!