### PR TITLE
Clean up inserted user on login e2e test

### DIFF
--- a/tests/e2e/onboarding.test.ts
+++ b/tests/e2e/onboarding.test.ts
@@ -127,6 +127,7 @@ test('onboarding with a short code', async ({ page }) => {
 test('login as existing user', async ({ page }) => {
 	const password = faker.internet.password()
 	const user = await insertNewUser({ password })
+	usernamesToDelete.add(user.username)
 	invariant(user.name, 'User name not found')
 	await page.goto('/login')
 	await page.getByRole('textbox', { name: /username/i }).fill(user.username)


### PR DESCRIPTION
Perhaps I'm missing something, but I was reading through the e2e test code, and in `onboarding with link`, we're clearly remembering the username we've signed up with to delete it after the test is over, but in `login as existing user`, we're inserting a user without marking it for later deletion. Maybe this isn't a problem because the e2e tests always start with a freshly seeded db? Or is this an oversight?

## Checklist

- [X] Tests updated
- [ ] Docs updated

