### PR TITLE
Standardizing Environment Checks: MODE vs. NODE_ENV

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -11,7 +11,7 @@ const callback = () =>
 		hydrateRoot(document, <RemixBrowser />)
 	})
 
-if (process.env.NODE_ENV === 'development') {
+if (ENV.MODE === 'development') {
 	import('remix-development-tools').then(({ initClient }) => {
 		// Add all the dev tools props here into the client
 		initClient()


### PR DESCRIPTION
While looking through the code, I saw that some files use `MODE` and others use `NODE_ENV` for checking the environment. Specifically, in this entry.client.ts file, we seem to be using both (see [this](https://github.com/epicweb-dev/epic-stack/pull/407/files#diff-c5698d7b301af51f1573ea4b61bbd1878710472917906bf4f779a64fc3055615R5-R7)). I've tried sticking to just `MODE` to keep it simple. Is there a reason we use both ways? And would it be okay to use just `MODE` in most places?