### PR TITLE
fix notes image upload

### DIFF
--- a/app/routes/users+/$username_+/__note-editor.tsx
+++ b/app/routes/users+/$username_+/__note-editor.tsx
@@ -52,14 +52,10 @@ const ImageFieldsetSchema = z.object({
 
 type ImageFieldset = z.infer<typeof ImageFieldsetSchema>
 
-function imageHasFileOrId(
+function imageHasFile(
 	image: ImageFieldset,
-): image is ImageFieldset &
-	(
-		| { file: NonNullable<ImageFieldset['file']> }
-		| { id: NonNullable<ImageFieldset['id']> }
-	) {
-	return Boolean(image.file || image.id)
+): image is ImageFieldset & { file: NonNullable<ImageFieldset['file']> } {
+	return Boolean(image.file?.size && image.file?.size > 0)
 }
 
 const NoteEditorSchema = z.object({
@@ -94,15 +90,19 @@ export async function action({ request }: DataFunctionArgs) {
 		}).transform(async ({ images = [], ...data }) => {
 			return {
 				...data,
-				images: await Promise.all(
-					images.filter(imageHasFileOrId).map(async image => ({
+				imageIds: images.map(i => i.id).filter(Boolean),
+				imageUpdates: images
+					.filter(i => i.id && !imageHasFile(i))
+					.map(i => ({
+						id: i.id,
+						altText: i.altText,
+					})),
+				imageUploads: await Promise.all(
+					images.filter(imageHasFile).map(async image => ({
 						id: image.id,
 						altText: image.altText,
-						contentType: image.file?.type,
-						blob:
-							image.file?.size && image.file.size > 0
-								? Buffer.from(await image.file.arrayBuffer())
-								: null,
+						contentType: image.file.type,
+						blob: Buffer.from(await image.file.arrayBuffer()),
 					})),
 				),
 			}
@@ -118,7 +118,14 @@ export async function action({ request }: DataFunctionArgs) {
 		return json({ status: 'error', submission } as const, { status: 400 })
 	}
 
-	const { id: noteId, title, content, images = [] } = submission.value
+	const {
+		id: noteId,
+		title,
+		content,
+		imageUploads = [],
+		imageUpdates = [],
+		imageIds,
+	} = submission.value
 
 	const updatedNote = await prisma.$transaction(async $prisma => {
 		const note = await $prisma.note.upsert({
@@ -133,33 +140,27 @@ export async function action({ request }: DataFunctionArgs) {
 				title,
 				content,
 				images: {
-					deleteMany: { id: { notIn: images.map(i => i.id).filter(Boolean) } },
+					deleteMany: { id: { notIn: imageIds } },
+					updateMany: imageUpdates.map(updates => ({
+						where: { id: updates.id },
+						data: updates,
+					})),
 				},
 			},
 		})
 
-		for (const image of images) {
-			const { blob, contentType } = image
-			if (blob && contentType) {
-				await $prisma.noteImage.upsert({
-					select: { id: true },
-					where: { id: image.id ?? '__new_image__' },
-					create: { ...image, blob, contentType, noteId: note.id },
-					update: {
-						...image,
-						blob,
-						// update the id since it is used for caching
-						id: cuid(),
-						noteId: note.id,
-					},
-				})
-			} else if (image.id) {
-				await $prisma.noteImage.update({
-					select: { id: true },
-					where: { id: image.id },
-					data: { altText: image.altText },
-				})
-			}
+		for (const image of imageUploads) {
+			await $prisma.noteImage.upsert({
+				select: { id: true },
+				where: { id: image.id ?? '__new_image__' },
+				create: { ...image, noteId: note.id },
+				update: {
+					...image,
+					// update the id since it is used for caching
+					id: cuid(),
+					noteId: note.id,
+				},
+			})
 		}
 
 		return note


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
Image upload for notes has a bug where _only_ adding an image to an existing note **deletes** the old one and _only_ adds the new one. (See below video)

https://github.com/epicweb-dev/epic-stack/assets/61059807/f218a67b-55ef-4db3-bc55-e5a29fd47bb3

This happens because the file entries without `File` are being stripped away by this [function](https://github.com/arpitdalal/epic-stack/blob/232249c6478d590dc208b8bd681aab329a12b132/app/routes/users%2B/%24username_%2B/__note-editor.tsx#L55) and since the existing images are only being passed as `id` in a hidden field, they're being stripped away.
As a solution, I've updated that function not to strip away any images that have id, see [here](https://github.com/arpitdalal/epic-stack/blob/9f0452a133e500711cecbc33f4fb33e3eaebfa9f/app/routes/users%2B/%24username_%2B/__note-editor.tsx#L55) and update related code in `transform` and `prisma query`.
See this video after this fix

https://github.com/epicweb-dev/epic-stack/assets/61059807/a03728b2-5622-4b13-aec1-b0291047d296

Let me know if you need me to make any changes.

## Test Plan
I couldn't find any tests already written for this, so haven't updated anything.
<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
