### PR TITLE
docs: Correct optional parameter syntax in caching code snippet

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -44,7 +44,7 @@ const eventSchema = z.object({
 export async function getScheduledEvents({
 	timings,
 }: {
-	timings: Timings
+	timings?: Timings
 } = {}) {
 	const scheduledEvents = await cachified({
 		key: 'tito:scheduled-events',


### PR DESCRIPTION
Hi all, I've corrected a minor TypeScript syntax error in the caching.md document regarding the optional timings parameter. 