### PR TITLE
Integrate Prettier formatting in SVG icon generator script

### DIFF
--- a/other/build-icons.ts
+++ b/other/build-icons.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path'
+import { $ } from 'execa'
 import fsExtra from 'fs-extra'
 import { glob } from 'glob'
 import { parse } from 'node-html-parser'
@@ -147,5 +148,6 @@ async function writeIfChanged(filepath: string, newContent: string) {
 		.catch(() => '')
 	if (currentContent === newContent) return false
 	await fsExtra.writeFile(filepath, newContent, 'utf8')
+	await $`prettier --write ${filepath}`
 	return true
 }


### PR DESCRIPTION
### Problem:
The current SVG icon generator script produces code that doesn't adhere to the Prettier code style guidelines. As a result, users often face unexpected diffs when running the `build:icons` or `format`.

### Example:
One such inconsistency is that the `type IconName` is generated using double quotes (`"`) and a semicolon - while Prettier enforces single quotes (`'`) and no semicolon.

### Proposed Solution:
To ensure consistent formatting, I've updated the `writeIfChanged` function in the icon generator script. After writing the new content to a file, Prettier is invoked to format the file according to the project's Prettier configuration.

```diff
async function writeIfChanged(filepath: string, newContent: string) {
	const currentContent = await fsExtra
		.readFile(filepath, 'utf8')
		.catch(() => '')
	if (currentContent === newContent) return false
	await fsExtra.writeFile(filepath, newContent, 'utf8')
+	await $`prettier --write ${filepath}`
	return true
}
```

### Considerations:
I realize that running Prettier for every file generation might seem excessive. However, this approach guarantees that the generated code will always comply with the project's Prettier configuration, preventing any unwanted diffs. An alternative approach is to adjust the code generation logic to produce Prettier-compliant code directly, but that would require manual adjustments if the Prettier configuration changes in the future.

I'm open to feedback and suggestions. If there's a preference to adjust the code generation logic instead, I'm happy to make that change.