### PR TITLE
add test cases for note images

### DIFF
--- a/tests/e2e/note-images.test.ts
+++ b/tests/e2e/note-images.test.ts
@@ -1,0 +1,154 @@
+import fs from 'fs'
+import { faker } from '@faker-js/faker'
+import { expect, test } from '@playwright/test'
+import { type NoteImage, type Note } from '@prisma/client'
+import { prisma } from '#app/utils/db.server.ts'
+import { insertedUsers, loginPage } from '#tests/playwright-utils.ts'
+
+test('Users can create note with an image', async ({ page }) => {
+	const user = await loginPage({ page })
+	await page.goto(`/users/${user.username}/notes`)
+
+	const newNote = createNote()
+	const altText = 'cute koala'
+	await page.getByRole('link', { name: 'new note' }).click()
+
+	// fill in form and submit
+	await page.getByRole('textbox', { name: 'title' }).fill(newNote.title)
+	await page.getByRole('textbox', { name: 'content' }).fill(newNote.content)
+	await page.setInputFiles(
+		"input[name='images[0].file']",
+		'tests/fixtures/images/kody-notes/cute-koala.png',
+	)
+	await page.getByRole('textbox', { name: 'alt text' }).fill(altText)
+
+	await page.getByRole('button', { name: 'submit' }).click()
+	await expect(page).toHaveURL(new RegExp(`/users/${user.username}/notes/.*`))
+	await expect(page.getByRole('heading', { name: newNote.title })).toBeVisible()
+	await expect(page.getByAltText(altText)).toBeVisible()
+})
+
+test('Users can create note with multiple images', async ({ page }) => {
+	const user = await loginPage({ page })
+	await page.goto(`/users/${user.username}/notes`)
+
+	const newNote = createNote()
+	const altText1 = 'cute koala'
+	const altText2 = 'koala coder'
+	await page.getByRole('link', { name: 'new note' }).click()
+
+	// fill in form and submit
+	await page.getByRole('textbox', { name: 'title' }).fill(newNote.title)
+	await page.getByRole('textbox', { name: 'content' }).fill(newNote.content)
+	await page.setInputFiles(
+		"input[name='images[0].file']",
+		'tests/fixtures/images/kody-notes/cute-koala.png',
+	)
+	await page
+		.locator('[id="note-editor-images\\[0\\]\\.altText"]')
+		.fill(altText1)
+	await page.getByRole('button', { name: 'add image' }).click()
+
+	await page.setInputFiles(
+		"input[name='images[1].file']",
+		'tests/fixtures/images/kody-notes/koala-coder.png',
+	)
+	await page
+		.locator('[id="note-editor-images\\[1\\]\\.altText"]')
+		.fill(altText2)
+
+	await page.getByRole('button', { name: 'submit' }).click()
+	await expect(page).toHaveURL(new RegExp(`/users/${user.username}/notes/.*`))
+	await expect(page.getByRole('heading', { name: newNote.title })).toBeVisible()
+	await expect(page.getByAltText(altText1)).toBeVisible()
+	await expect(page.getByAltText(altText2)).toBeVisible()
+})
+
+test('Users can edit note image', async ({ page }) => {
+	const user = await loginPage({ page })
+
+	const note = await prisma.note.create({
+		select: { id: true },
+		data: {
+			...createNoteWithImage(),
+			ownerId: user.id,
+		},
+	})
+	await page.goto(`/users/${user.username}/notes/${note.id}`)
+
+	// edit the image
+	await page.getByRole('link', { name: 'Edit', exact: true }).click()
+	const updatedImage = {
+		altText: 'koala coder',
+		url: 'tests/fixtures/images/kody-notes/koala-coder.png',
+	}
+	await page.setInputFiles("input[name='images[0].file']", updatedImage.url)
+	await page
+		.locator('[id="note-editor-images\\[0\\]\\.altText"]')
+		.fill(updatedImage.altText)
+	await page.getByRole('button', { name: 'submit' }).click()
+
+	await expect(page).toHaveURL(new RegExp(`/users/${user.username}/notes/.*`))
+	await expect(page.getByAltText(updatedImage.altText)).toBeVisible()
+})
+
+test('Users can delete note image', async ({ page }) => {
+	const user = await loginPage({ page })
+
+	const note = await prisma.note.create({
+		select: { id: true, title: true },
+		data: {
+			...createNoteWithImage(),
+			ownerId: user.id,
+		},
+	})
+	await page.goto(`/users/${user.username}/notes/${note.id}`)
+
+	await expect(page.getByRole('heading', { name: note.title })).toBeVisible()
+	// find image tags
+	const images = page
+		.getByRole('main')
+		.getByRole('list')
+		.getByRole('listitem')
+		.getByRole('img')
+	const countBefore = await images.count()
+	await page.getByRole('link', { name: 'Edit', exact: true }).click()
+	await page.getByRole('button', { name: 'remove image' }).click()
+	await page.getByRole('button', { name: 'submit' }).click()
+	await expect(page).toHaveURL(new RegExp(`/users/${user.username}/notes/.*`))
+	const countAfter = await images.count()
+	expect(countAfter).toEqual(countBefore - 1)
+})
+
+function createNote() {
+	return {
+		title: faker.lorem.words(3),
+		content: faker.lorem.paragraphs(3),
+	} satisfies Omit<Note, 'id' | 'createdAt' | 'updatedAt' | 'type' | 'ownerId'>
+}
+function createNoteWithImage() {
+	return {
+		...createNote(),
+		images: {
+			create: {
+				altText: 'cute koala',
+				contentType: 'image/png',
+				blob: fs.readFileSync(
+					'tests/fixtures/images/kody-notes/cute-koala.png',
+				),
+			},
+		},
+	} satisfies Omit<
+		Note,
+		'id' | 'createdAt' | 'updatedAt' | 'type' | 'ownerId'
+	> & {
+		images: { create: Pick<NoteImage, 'altText' | 'blob' | 'contentType'> }
+	}
+}
+
+test.afterEach(async () => {
+	await prisma.user.deleteMany({
+		where: { id: { in: Array.from(insertedUsers) } },
+	})
+	insertedUsers.clear()
+})

--- a/tests/e2e/note-images.test.ts
+++ b/tests/e2e/note-images.test.ts
@@ -76,9 +76,9 @@ test('Users can edit note image', async ({ page }) => {
 	await page.getByRole('link', { name: 'Edit', exact: true }).click()
 	const updatedImage = {
 		altText: 'koala coder',
-		url: 'tests/fixtures/images/kody-notes/koala-coder.png',
+		location: 'tests/fixtures/images/kody-notes/koala-coder.png',
 	}
-	await page.getByLabel('image').nth(0).setInputFiles(updatedImage.url)
+	await page.getByLabel('image').nth(0).setInputFiles(updatedImage.location)
 	await page.getByLabel('alt text').nth(0).fill(updatedImage.altText)
 	await page.getByRole('button', { name: 'submit' }).click()
 

--- a/tests/e2e/note-images.test.ts
+++ b/tests/e2e/note-images.test.ts
@@ -1,12 +1,11 @@
 import fs from 'fs'
 import { faker } from '@faker-js/faker'
-import { expect, test } from '@playwright/test'
 import { type NoteImage, type Note } from '@prisma/client'
 import { prisma } from '#app/utils/db.server.ts'
-import { loginPage } from '#tests/playwright-utils.ts'
+import { expect, test } from '#tests/playwright-utils.ts'
 
-test('Users can create note with an image', async ({ page }) => {
-	const user = await loginPage({ page })
+test('Users can create note with an image', async ({ page, login }) => {
+	const user = await login()
 	await page.goto(`/users/${user.username}/notes`)
 
 	const newNote = createNote()
@@ -28,8 +27,8 @@ test('Users can create note with an image', async ({ page }) => {
 	await expect(page.getByAltText(altText)).toBeVisible()
 })
 
-test('Users can create note with multiple images', async ({ page }) => {
-	const user = await loginPage({ page })
+test('Users can create note with multiple images', async ({ page, login }) => {
+	const user = await login()
 	await page.goto(`/users/${user.username}/notes`)
 
 	const newNote = createNote()
@@ -60,8 +59,8 @@ test('Users can create note with multiple images', async ({ page }) => {
 	await expect(page.getByAltText(altText2)).toBeVisible()
 })
 
-test('Users can edit note image', async ({ page }) => {
-	const user = await loginPage({ page })
+test('Users can edit note image', async ({ page, login }) => {
+	const user = await login()
 
 	const note = await prisma.note.create({
 		select: { id: true },
@@ -86,8 +85,8 @@ test('Users can edit note image', async ({ page }) => {
 	await expect(page.getByAltText(updatedImage.altText)).toBeVisible()
 })
 
-test('Users can delete note image', async ({ page }) => {
-	const user = await loginPage({ page })
+test('Users can delete note image', async ({ page, login }) => {
+	const user = await login()
 
 	const note = await prisma.note.create({
 		select: { id: true, title: true },

--- a/tests/e2e/note-images.test.ts
+++ b/tests/e2e/note-images.test.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { expect, test } from '@playwright/test'
 import { type NoteImage, type Note } from '@prisma/client'
 import { prisma } from '#app/utils/db.server.ts'
-import { insertedUsers, loginPage } from '#tests/playwright-utils.ts'
+import { loginPage } from '#tests/playwright-utils.ts'
 
 test('Users can create note with an image', async ({ page }) => {
 	const user = await loginPage({ page })
@@ -145,10 +145,3 @@ function createNoteWithImage() {
 		images: { create: Pick<NoteImage, 'altText' | 'blob' | 'contentType'> }
 	}
 }
-
-test.afterEach(async () => {
-	await prisma.user.deleteMany({
-		where: { id: { in: Array.from(insertedUsers) } },
-	})
-	insertedUsers.clear()
-})

--- a/tests/e2e/note-images.test.ts
+++ b/tests/e2e/note-images.test.ts
@@ -16,10 +16,10 @@ test('Users can create note with an image', async ({ page }) => {
 	// fill in form and submit
 	await page.getByRole('textbox', { name: 'title' }).fill(newNote.title)
 	await page.getByRole('textbox', { name: 'content' }).fill(newNote.content)
-	await page.setInputFiles(
-		"input[name='images[0].file']",
-		'tests/fixtures/images/kody-notes/cute-koala.png',
-	)
+	await page
+		.getByLabel('image')
+		.nth(0)
+		.setInputFiles('tests/fixtures/images/kody-notes/cute-koala.png')
 	await page.getByRole('textbox', { name: 'alt text' }).fill(altText)
 
 	await page.getByRole('button', { name: 'submit' }).click()
@@ -40,17 +40,17 @@ test('Users can create note with multiple images', async ({ page }) => {
 	// fill in form and submit
 	await page.getByRole('textbox', { name: 'title' }).fill(newNote.title)
 	await page.getByRole('textbox', { name: 'content' }).fill(newNote.content)
-	await page.setInputFiles(
-		"input[name='images[0].file']",
-		'tests/fixtures/images/kody-notes/cute-koala.png',
-	)
+	await page
+		.getByLabel('image')
+		.nth(0)
+		.setInputFiles('tests/fixtures/images/kody-notes/cute-koala.png')
 	await page.getByLabel('alt text').nth(0).fill(altText1)
 	await page.getByRole('button', { name: 'add image' }).click()
 
-	await page.setInputFiles(
-		"input[name='images[1].file']",
-		'tests/fixtures/images/kody-notes/koala-coder.png',
-	)
+	await page
+		.getByLabel('image')
+		.nth(1)
+		.setInputFiles('tests/fixtures/images/kody-notes/koala-coder.png')
 	await page.getByLabel('alt text').nth(1).fill(altText2)
 
 	await page.getByRole('button', { name: 'submit' }).click()
@@ -78,7 +78,7 @@ test('Users can edit note image', async ({ page }) => {
 		altText: 'koala coder',
 		url: 'tests/fixtures/images/kody-notes/koala-coder.png',
 	}
-	await page.setInputFiles("input[name='images[0].file']", updatedImage.url)
+	await page.getByLabel('image').nth(0).setInputFiles(updatedImage.url)
 	await page.getByLabel('alt text').nth(0).fill(updatedImage.altText)
 	await page.getByRole('button', { name: 'submit' }).click()
 

--- a/tests/e2e/note-images.test.ts
+++ b/tests/e2e/note-images.test.ts
@@ -44,18 +44,14 @@ test('Users can create note with multiple images', async ({ page }) => {
 		"input[name='images[0].file']",
 		'tests/fixtures/images/kody-notes/cute-koala.png',
 	)
-	await page
-		.locator('[id="note-editor-images\\[0\\]\\.altText"]')
-		.fill(altText1)
+	await page.getByLabel('alt text').nth(0).fill(altText1)
 	await page.getByRole('button', { name: 'add image' }).click()
 
 	await page.setInputFiles(
 		"input[name='images[1].file']",
 		'tests/fixtures/images/kody-notes/koala-coder.png',
 	)
-	await page
-		.locator('[id="note-editor-images\\[1\\]\\.altText"]')
-		.fill(altText2)
+	await page.getByLabel('alt text').nth(1).fill(altText2)
 
 	await page.getByRole('button', { name: 'submit' }).click()
 	await expect(page).toHaveURL(new RegExp(`/users/${user.username}/notes/.*`))
@@ -83,9 +79,7 @@ test('Users can edit note image', async ({ page }) => {
 		url: 'tests/fixtures/images/kody-notes/koala-coder.png',
 	}
 	await page.setInputFiles("input[name='images[0].file']", updatedImage.url)
-	await page
-		.locator('[id="note-editor-images\\[0\\]\\.altText"]')
-		.fill(updatedImage.altText)
+	await page.getByLabel('alt text').nth(0).fill(updatedImage.altText)
 	await page.getByRole('button', { name: 'submit' }).click()
 
 	await expect(page).toHaveURL(new RegExp(`/users/${user.username}/notes/.*`))


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
Adding tests for note images.
The following tests are included:

1. Users can create note with an image
2. Users can create note with multiple images
3. Users can edit note image
4. Users can delete note image

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [x] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
