### PR TITLE
fix prettier error for unknown file types in writeIfChanged

### DIFF
--- a/other/build-icons.ts
+++ b/other/build-icons.ts
@@ -148,6 +148,6 @@ async function writeIfChanged(filepath: string, newContent: string) {
 		.catch(() => '')
 	if (currentContent === newContent) return false
 	await fsExtra.writeFile(filepath, newContent, 'utf8')
-	await $`prettier --write ${filepath}`
+	await $`prettier --write ${filepath} --ignore-unknown`
 	return true
 }


### PR DESCRIPTION
### Description:
This PR addresses an [issue](https://github.com/epicweb-dev/epic-stack/issues#issuecomment-1702007326) where running Prettier on created svg files throws an error. The issue is caused by Prettier not recognizing the `.svg` file format by default. 

### Steps to Reproduce:
1. Create a new epic-stack project.
2. Observe the error when the `writeIfChanged` function attempts to run Prettier on the `sprite.svg` file.
3. With the changes in this PR, the error should no longer occur.

### Changes:
- Added the `--ignore-unknown` flag to the `prettier --write` command in the `writeIfChanged` function. This ensures that Prettier will gracefully ignore file types it does not recognize, rather than throwing an error.

```diff
async function writeIfChanged(filepath: string, newContent: string) {
	const currentContent = await fsExtra
		.readFile(filepath, 'utf8')
		.catch(() => '')
	if (currentContent === newContent) return false
	await fsExtra.writeFile(filepath, newContent, 'utf8')
-       await $`prettier --write ${filepath}`
+       await $`prettier --write ${filepath} --ignore-unknown`
	return true
}
 ```

### Relevant Documentation:
Prettier's [`--ignore-unknown`](https://prettier.io/docs/en/cli.html#--ignore-unknown) flag is used to ignore unknown files matched by patterns. 

### Fixes:
- https://github.com/epicweb-dev/epic-stack/issues#issuecomment-1702007326

Thank you @sergio-codel-io for reporting the issue

