### PR TITLE
Hide logs for images and Healthcheck

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -90,7 +90,15 @@ app.use(
 app.use(express.static('public', { maxAge: '1h' }))
 
 morgan.token('url', (req, res) => decodeURIComponent(req.url ?? ''))
-app.use(morgan('tiny'))
+app.use(
+	morgan('tiny', {
+		skip: (req, res) =>
+			res.statusCode === 200 &&
+			(req.url?.startsWith('/resources/note-images') ||
+				req.url?.startsWith('/resources/user-images') ||
+				req.url?.startsWith('/resources/healthcheck')),
+	}),
+)
 
 app.use((_, res, next) => {
 	res.locals.cspNonce = crypto.randomBytes(16).toString('hex')


### PR DESCRIPTION
If the response of the image or the healthcheck is ok, then we can skip them, otherwise a logs can be pretty useful.

I added the healthcheck path because they generate a lot of logs on deployment and only error healthcheck are interesting.

This should close #368 

## Test Plan

Disable network cache, and check the logs.

## Checklist

- [ ] Tests updated
- [ ] Docs updated
