### PR TITLE
Minor improvements on forms setup 

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -173,11 +173,6 @@ const ThemeFormSchema = z.object({
 
 export async function action({ request }: DataFunctionArgs) {
 	const formData = await request.formData()
-	invariantResponse(
-		formData.get('intent') === 'update-theme',
-		'Invalid intent',
-		{ status: 400 },
-	)
 	const submission = parse(formData, {
 		schema: ThemeFormSchema,
 	})
@@ -365,10 +360,7 @@ export function useTheme() {
  */
 export function useOptimisticThemeMode() {
 	const fetchers = useFetchers()
-
-	const themeFetcher = fetchers.find(
-		f => f.formData?.get('intent') === 'update-theme',
-	)
+	const themeFetcher = fetchers.find(f => f.formAction === '/')
 
 	if (themeFetcher && themeFetcher.formData) {
 		const submission = parse(themeFetcher.formData, {
@@ -384,9 +376,6 @@ function ThemeSwitch({ userPreference }: { userPreference?: Theme | null }) {
 	const [form] = useForm({
 		id: 'theme-switch',
 		lastSubmission: fetcher.data?.submission,
-		onValidate({ formData }) {
-			return parse(formData, { schema: ThemeFormSchema })
-		},
 	})
 
 	const optimisticMode = useOptimisticThemeMode()
@@ -416,8 +405,6 @@ function ThemeSwitch({ userPreference }: { userPreference?: Theme | null }) {
 			<input type="hidden" name="theme" value={nextMode} />
 			<div className="flex gap-2">
 				<button
-					name="intent"
-					value="update-theme"
 					type="submit"
 					className="flex h-8 w-8 cursor-pointer items-center justify-center"
 				>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -51,7 +51,6 @@ import {
 	combineHeaders,
 	getDomainUrl,
 	getUserImgSrc,
-	invariantResponse,
 } from './utils/misc.tsx'
 import { useNonce } from './utils/nonce-provider.ts'
 import { useRequestInfo } from './utils/request-info.ts'

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -182,7 +182,7 @@ export async function action({ request }: DataFunctionArgs) {
 		schema: ThemeFormSchema,
 	})
 	if (submission.intent !== 'submit') {
-		return json({ status: 'success', submission } as const)
+		return json({ status: 'idle', submission } as const)
 	}
 	if (!submission.value) {
 		return json({ status: 'error', submission } as const, { status: 400 })

--- a/app/routes/_auth+/login.tsx
+++ b/app/routes/_auth+/login.tsx
@@ -267,10 +267,7 @@ export default function LoginPage() {
 					<div className="mx-auto w-full max-w-md px-8">
 						<Form method="POST" {...form.props}>
 							<Field
-								labelProps={{
-									htmlFor: fields.username.id,
-									children: 'Username',
-								}}
+								labelProps={{ children: 'Username' }}
 								inputProps={{
 									...conform.input(fields.username),
 									autoFocus: true,
@@ -280,10 +277,7 @@ export default function LoginPage() {
 							/>
 
 							<Field
-								labelProps={{
-									htmlFor: fields.password.id,
-									children: 'Password',
-								}}
+								labelProps={{ children: 'Password' }}
 								inputProps={conform.input(fields.password, {
 									type: 'password',
 								})}

--- a/app/routes/_auth+/login.tsx
+++ b/app/routes/_auth+/login.tsx
@@ -203,7 +203,7 @@ export async function action({ request }: DataFunctionArgs) {
 				const session = await login(data)
 				if (!session) {
 					ctx.addIssue({
-						code: 'custom',
+						code: z.ZodIssueCode.custom,
 						message: 'Invalid username or password',
 					})
 					return z.NEVER

--- a/app/routes/_auth+/login.tsx
+++ b/app/routes/_auth+/login.tsx
@@ -267,7 +267,10 @@ export default function LoginPage() {
 					<div className="mx-auto w-full max-w-md px-8">
 						<Form method="POST" {...form.props}>
 							<Field
-								labelProps={{ children: 'Username' }}
+								labelProps={{
+									htmlFor: fields.username.id,
+									children: 'Username',
+								}}
 								inputProps={{
 									...conform.input(fields.username),
 									autoFocus: true,
@@ -277,7 +280,10 @@ export default function LoginPage() {
 							/>
 
 							<Field
-								labelProps={{ children: 'Password' }}
+								labelProps={{
+									htmlFor: fields.password.id,
+									children: 'Password',
+								}}
 								inputProps={conform.input(fields.password, {
 									type: 'password',
 								})}

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -50,7 +50,7 @@ const SignupFormSchema = z
 				if (confirmPassword !== password) {
 					ctx.addIssue({
 						path: ['confirmPassword'],
-						code: 'custom',
+						code: z.ZodIssueCode.custom,
 						message: 'The passwords must match',
 					})
 				}

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -36,8 +36,6 @@ const SignupFormSchema = z
 	.object({
 		username: UsernameSchema,
 		name: NameSchema,
-		password: PasswordSchema,
-		confirmPassword: PasswordSchema,
 		agreeToTermsOfServiceAndPrivacyPolicy: z.boolean({
 			required_error:
 				'You must agree to the terms of service and privacy policy',
@@ -45,15 +43,19 @@ const SignupFormSchema = z
 		remember: z.boolean().optional(),
 		redirectTo: z.string().optional(),
 	})
-	.superRefine(({ confirmPassword, password }, ctx) => {
-		if (confirmPassword !== password) {
-			ctx.addIssue({
-				path: ['confirmPassword'],
-				code: 'custom',
-				message: 'The passwords must match',
-			})
-		}
-	})
+	.and(
+		z
+			.object({ password: PasswordSchema, confirmPassword: PasswordSchema })
+			.superRefine(({ confirmPassword, password }, ctx) => {
+				if (confirmPassword !== password) {
+					ctx.addIssue({
+						path: ['confirmPassword'],
+						code: 'custom',
+						message: 'The passwords must match',
+					})
+				}
+			}),
+	)
 
 async function requireOnboardingEmail(request: Request) {
 	await requireAnonymous(request)

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -36,6 +36,8 @@ const SignupFormSchema = z
 	.object({
 		username: UsernameSchema,
 		name: NameSchema,
+		password: PasswordSchema,
+		confirmPassword: PasswordSchema,
 		agreeToTermsOfServiceAndPrivacyPolicy: z.boolean({
 			required_error:
 				'You must agree to the terms of service and privacy policy',
@@ -43,19 +45,15 @@ const SignupFormSchema = z
 		remember: z.boolean().optional(),
 		redirectTo: z.string().optional(),
 	})
-	.and(
-		z
-			.object({ password: PasswordSchema, confirmPassword: PasswordSchema })
-			.superRefine(({ confirmPassword, password }, ctx) => {
-				if (confirmPassword !== password) {
-					ctx.addIssue({
-						path: ['confirmPassword'],
-						code: z.ZodIssueCode.custom,
-						message: 'The passwords must match',
-					})
-				}
-			}),
-	)
+	.superRefine(({ confirmPassword, password }, ctx) => {
+		if (confirmPassword !== password) {
+			ctx.addIssue({
+				path: ['confirmPassword'],
+				code: z.ZodIssueCode.custom,
+				message: 'The passwords must match',
+			})
+		}
+	})
 
 async function requireOnboardingEmail(request: Request) {
 	await requireAnonymous(request)

--- a/app/routes/_auth+/verify.tsx
+++ b/app/routes/_auth+/verify.tsx
@@ -177,22 +177,21 @@ async function validateRequest(
 	body: URLSearchParams | FormData,
 ) {
 	const submission = await parse(body, {
-		schema: () =>
-			VerifySchema.superRefine(async (data, ctx) => {
-				const codeIsValid = await isCodeValid({
-					code: data[codeQueryParam],
-					type: data[typeQueryParam],
-					target: data[targetQueryParam],
+		schema: VerifySchema.superRefine(async (data, ctx) => {
+			const codeIsValid = await isCodeValid({
+				code: data[codeQueryParam],
+				type: data[typeQueryParam],
+				target: data[targetQueryParam],
+			})
+			if (!codeIsValid) {
+				ctx.addIssue({
+					path: ['code'],
+					code: z.ZodIssueCode.custom,
+					message: `Invalid code`,
 				})
-				if (!codeIsValid) {
-					ctx.addIssue({
-						path: ['code'],
-						code: z.ZodIssueCode.custom,
-						message: `Invalid code`,
-					})
-					return
-				}
-			}),
+				return
+			}
+		}),
 		async: true,
 	})
 

--- a/app/routes/settings+/profile.change-email.tsx
+++ b/app/routes/settings+/profile.change-email.tsx
@@ -106,7 +106,7 @@ export async function action({ request }: DataFunctionArgs) {
 			if (existingUser) {
 				ctx.addIssue({
 					path: ['email'],
-					code: 'custom',
+					code: z.ZodIssueCode.custom,
 					message: 'This email is already in use.',
 				})
 			}

--- a/app/routes/settings+/profile.change-email.tsx
+++ b/app/routes/settings+/profile.change-email.tsx
@@ -226,7 +226,7 @@ export default function ChangeEmailIndex() {
 			<div className="mx-auto mt-5 max-w-sm">
 				<Form method="POST" {...form.props}>
 					<Field
-						labelProps={{ htmlFor: fields.email.id, children: 'New Email' }}
+						labelProps={{ children: 'New Email' }}
 						inputProps={conform.input(fields.email)}
 						errors={fields.email.errors}
 					/>

--- a/app/routes/settings+/profile.change-email.tsx
+++ b/app/routes/settings+/profile.change-email.tsx
@@ -226,7 +226,7 @@ export default function ChangeEmailIndex() {
 			<div className="mx-auto mt-5 max-w-sm">
 				<Form method="POST" {...form.props}>
 					<Field
-						labelProps={{ children: 'New Email' }}
+						labelProps={{ htmlFor: fields.email.id, children: 'New Email' }}
 						inputProps={conform.input(fields.email)}
 						errors={fields.email.errors}
 					/>

--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -185,7 +185,7 @@ async function profileUpdateAction({ userId, formData }: ProfileActionArgs) {
 			if (existingUsername && existingUsername.id !== userId) {
 				ctx.addIssue({
 					path: ['username'],
-					code: 'custom',
+					code: z.ZodIssueCode.custom,
 					message: 'A user already exists with this username',
 				})
 			}

--- a/app/routes/settings+/profile.password.tsx
+++ b/app/routes/settings+/profile.password.tsx
@@ -34,7 +34,7 @@ const ChangePasswordForm = z
 		if (confirmNewPassword !== newPassword) {
 			ctx.addIssue({
 				path: ['confirmNewPassword'],
-				code: 'custom',
+				code: z.ZodIssueCode.custom,
 				message: 'The passwords must match',
 			})
 		}
@@ -69,7 +69,7 @@ export async function action({ request }: DataFunctionArgs) {
 					if (!user) {
 						ctx.addIssue({
 							path: ['currentPassword'],
-							code: 'custom',
+							code: z.ZodIssueCode.custom,
 							message: 'Incorrect password.',
 						})
 					}

--- a/app/routes/settings+/profile.password_.create.tsx
+++ b/app/routes/settings+/profile.password_.create.tsx
@@ -28,7 +28,7 @@ const CreatePasswordForm = z
 		if (confirmNewPassword !== newPassword) {
 			ctx.addIssue({
 				path: ['confirmNewPassword'],
-				code: 'custom',
+				code: z.ZodIssueCode.custom,
 				message: 'The passwords must match',
 			})
 		}

--- a/app/routes/settings+/profile.password_.create.tsx
+++ b/app/routes/settings+/profile.password_.create.tsx
@@ -103,12 +103,18 @@ export default function CreatePasswordRoute() {
 	return (
 		<Form method="POST" {...form.props} className="mx-auto max-w-md">
 			<Field
-				labelProps={{ children: 'New Password' }}
+				labelProps={{
+					htmlFor: fields.newPassword.id,
+					children: 'New Password',
+				}}
 				inputProps={conform.input(fields.newPassword, { type: 'password' })}
 				errors={fields.newPassword.errors}
 			/>
 			<Field
-				labelProps={{ children: 'Confirm New Password' }}
+				labelProps={{
+					htmlFor: fields.confirmNewPassword.id,
+					children: 'Confirm New Password',
+				}}
 				inputProps={conform.input(fields.confirmNewPassword, {
 					type: 'password',
 				})}

--- a/app/routes/settings+/profile.password_.create.tsx
+++ b/app/routes/settings+/profile.password_.create.tsx
@@ -103,18 +103,12 @@ export default function CreatePasswordRoute() {
 	return (
 		<Form method="POST" {...form.props} className="mx-auto max-w-md">
 			<Field
-				labelProps={{
-					htmlFor: fields.newPassword.id,
-					children: 'New Password',
-				}}
+				labelProps={{ children: 'New Password' }}
 				inputProps={conform.input(fields.newPassword, { type: 'password' })}
 				errors={fields.newPassword.errors}
 			/>
 			<Field
-				labelProps={{
-					htmlFor: fields.confirmNewPassword.id,
-					children: 'Confirm New Password',
-				}}
+				labelProps={{ children: 'Confirm New Password' }}
 				inputProps={conform.input(fields.confirmNewPassword, {
 					type: 'password',
 				})}

--- a/app/routes/users+/$username_+/__note-editor.tsx
+++ b/app/routes/users+/$username_+/__note-editor.tsx
@@ -89,7 +89,7 @@ export async function action({ request }: DataFunctionArgs) {
 			})
 			if (!note) {
 				ctx.addIssue({
-					code: 'custom',
+					code: z.ZodIssueCode.custom,
 					message: 'Note not found',
 				})
 			}

--- a/app/routes/users+/$username_+/__note-editor.tsx
+++ b/app/routes/users+/$username_+/__note-editor.tsx
@@ -218,7 +218,7 @@ export function NoteEditor({
 				{note ? <input type="hidden" name="id" value={note.id} /> : null}
 				<div className="flex flex-col gap-1">
 					<Field
-						labelProps={{ children: 'Title' }}
+						labelProps={{ htmlFor: fields.title.id, children: 'Title' }}
 						inputProps={{
 							autoFocus: true,
 							...conform.input(fields.title, { ariaAttributes: true }),
@@ -226,7 +226,7 @@ export function NoteEditor({
 						errors={fields.title.errors}
 					/>
 					<TextareaField
-						labelProps={{ children: 'Content' }}
+						labelProps={{ htmlFor: fields.content.id, children: 'Content' }}
 						textareaProps={{
 							...conform.textarea(fields.content, { ariaAttributes: true }),
 						}}

--- a/app/routes/users+/$username_+/__note-editor.tsx
+++ b/app/routes/users+/$username_+/__note-editor.tsx
@@ -218,7 +218,7 @@ export function NoteEditor({
 				{note ? <input type="hidden" name="id" value={note.id} /> : null}
 				<div className="flex flex-col gap-1">
 					<Field
-						labelProps={{ htmlFor: fields.title.id, children: 'Title' }}
+						labelProps={{ children: 'Title' }}
 						inputProps={{
 							autoFocus: true,
 							...conform.input(fields.title, { ariaAttributes: true }),
@@ -226,7 +226,7 @@ export function NoteEditor({
 						errors={fields.title.errors}
 					/>
 					<TextareaField
-						labelProps={{ htmlFor: fields.content.id, children: 'Content' }}
+						labelProps={{ children: 'Content' }}
 						textareaProps={{
 							...conform.textarea(fields.content, { ariaAttributes: true }),
 						}}

--- a/app/routes/users+/$username_+/notes.$noteId.tsx
+++ b/app/routes/users+/$username_+/notes.$noteId.tsx
@@ -1,5 +1,5 @@
 import { useForm } from '@conform-to/react'
-import { getFieldsetConstraint, parse } from '@conform-to/zod'
+import { parse } from '@conform-to/zod'
 import { json, type DataFunctionArgs } from '@remix-run/node'
 import {
 	Form,

--- a/app/routes/users+/$username_+/notes.$noteId.tsx
+++ b/app/routes/users+/$username_+/notes.$noteId.tsx
@@ -164,10 +164,6 @@ export function DeleteNote({ id }: { id: string }) {
 	const [form] = useForm({
 		id: 'delete-note',
 		lastSubmission: actionData?.submission,
-		constraint: getFieldsetConstraint(DeleteFormSchema),
-		onValidate({ formData }) {
-			return parse(formData, { schema: DeleteFormSchema })
-		},
 	})
 
 	return (


### PR DESCRIPTION
I was reviewing the setup and noticed a few minor issues:

- [Narrowed zod refine scope for early feedback](https://github.com/epicweb-dev/epic-stack/commit/38cc88699f85acaf6ee5377b4d7add93c7bf3673)
- [Fixed missing `htmlFor` attribute](https://github.com/epicweb-dev/epic-stack/commit/0077095afa4c1fcf32d93d63217d727b0eaf6f92)
- [Simplified schema option passed to the parse helper](https://github.com/epicweb-dev/epic-stack/commit/cc7808e3f0fb9dfc8cee2be3789cf37ba6ce540d)
- [Replaced all hardcoded issue code with the one exported by zod](https://github.com/epicweb-dev/epic-stack/commit/9d84fc25e3344fc2d364602f3f3e19c86458e0de)
- [Fixed the status returned when checking submission intent](https://github.com/epicweb-dev/epic-stack/commit/59f1f145ecca728a61a11a4f021e98de2bc7e483)

There are also two forms could be simplified by removing the client validation and constraint:     

- [Removed unnecessary constraint and client validation setup on the delete note form](https://github.com/epicweb-dev/epic-stack/commit/09d7922460615aff3d7f22468a624e4bfe16a332)
- [Simplify theme switcher setup by removing client validation and lookup fetcher using form action instead of a custom intent](https://github.com/epicweb-dev/epic-stack/commit/f6b01bb4646d78cfe554d0954720fd1a31bb24ba)