### PR TITLE
Remove node version 16 from maintained versions list

### DIFF
--- a/docs/decisions/021-node-version.md
+++ b/docs/decisions/021-node-version.md
@@ -8,7 +8,7 @@ Status: accepted
 
 Node.js has a regular release cycle which is documented in the
 [release schedule](https://nodejs.org/en/about/releases/). At the time of this
-writing, there are 3 stable maintained releases: 16, 18, and 20. I'll refer you
+writing, there are 2 stable maintained releases: 18, and 20. I'll refer you
 to that documentation to understand how the release cycle works.
 
 Deciding which version of Node.js to use for a project is a trade-off between


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
Version 16 of Node.JS is now end of life so you can delete it from the list of maintained versions in [021-node-version.md](https://github.com/epicweb-dev/epic-stack/blob/main/docs/decisions/021-node-version.md) doc.

ref issue #438 

Check Node.JS Twitter's account [Tweet](https://twitter.com/nodejs/status/1701309614263001569).

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [x] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
