### PR TITLE
fix: some form id renamed to reflect the route it belongs to

### DIFF
--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -147,7 +147,7 @@ export default function SignupRoute() {
 	const redirectTo = searchParams.get('redirectTo')
 
 	const [form, fields] = useForm({
-		id: 'signup-form',
+		id: 'onboarding-form',
 		constraint: getFieldsetConstraint(SignupFormSchema),
 		defaultValue: { redirectTo },
 		lastSubmission: actionData?.submission,

--- a/app/routes/_auth+/onboarding_.$provider.tsx
+++ b/app/routes/_auth+/onboarding_.$provider.tsx
@@ -189,7 +189,7 @@ export default function SignupRoute() {
 	const redirectTo = searchParams.get('redirectTo')
 
 	const [form, fields] = useForm({
-		id: 'signup-form',
+		id: 'onboarding-provider-form',
 		constraint: getFieldsetConstraint(SignupFormSchema),
 		lastSubmission: actionData?.submission ?? data.submission,
 		onValidate({ formData }) {

--- a/app/routes/settings+/profile.password.tsx
+++ b/app/routes/settings+/profile.password.tsx
@@ -115,7 +115,7 @@ export default function ChangePasswordRoute() {
 	const isPending = useIsPending()
 
 	const [form, fields] = useForm({
-		id: 'signup-form',
+		id: 'password-change-form',
 		constraint: getFieldsetConstraint(ChangePasswordForm),
 		lastSubmission: actionData?.submission,
 		onValidate({ formData }) {

--- a/app/routes/settings+/profile.password_.create.tsx
+++ b/app/routes/settings+/profile.password_.create.tsx
@@ -88,7 +88,7 @@ export default function CreatePasswordRoute() {
 	const isPending = useIsPending()
 
 	const [form, fields] = useForm({
-		id: 'signup-form',
+		id: 'password-create-form',
 		constraint: getFieldsetConstraint(CreatePasswordForm),
 		lastSubmission: actionData?.submission,
 		onValidate({ formData }) {


### PR DESCRIPTION
I noticed some form ids where all `signup-form`. I assumed this undesired and thought I would submit a small PR to help out.

Thanks for this great repo! 🙏 🚀

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
