### PR TITLE
test: rework Playwright cleanup using fixtures

### DIFF
--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -2,12 +2,16 @@ import fs from 'node:fs'
 import { faker } from '@faker-js/faker'
 import bcrypt from 'bcryptjs'
 import { UniqueEnforcer } from 'enforce-unique'
-import { getPasswordHash } from '#app/utils/auth.server.ts'
-import { prisma } from '#app/utils/db.server.ts'
+
+export type User = {
+	username: string
+	name: string
+	email: string
+}
 
 const uniqueUsernameEnforcer = new UniqueEnforcer()
 
-export function createUser() {
+export function createUser(): User {
 	const firstName = faker.person.firstName()
 	const lastName = faker.person.lastName()
 
@@ -36,31 +40,6 @@ export function createPassword(password: string = faker.internet.password()) {
 	return {
 		hash: bcrypt.hashSync(password, 10),
 	}
-}
-
-export const insertedUsers = new Set<string>()
-
-export async function insertNewUser({
-	username,
-	password,
-	email,
-}: { username?: string; password?: string; email?: string } = {}) {
-	const userData = createUser()
-	username ??= userData.username
-	password ??= userData.username
-	email ??= userData.email
-	const user = await prisma.user.create({
-		select: { id: true, name: true, username: true, email: true },
-		data: {
-			...userData,
-			email,
-			username,
-			roles: { connect: { name: 'user' } },
-			password: { create: { hash: await getPasswordHash(password) } },
-		},
-	})
-	insertedUsers.add(user.id)
-	return user as typeof user & { name: string }
 }
 
 let noteImages: Array<Awaited<ReturnType<typeof img>>> | undefined

--- a/tests/e2e/2fa.test.ts
+++ b/tests/e2e/2fa.test.ts
@@ -1,14 +1,15 @@
 import { generateTOTP } from '@epic-web/totp'
 import { faker } from '@faker-js/faker'
-import { expect, test } from '@playwright/test'
-import { insertNewUser, loginPage } from '#tests/playwright-utils.ts'
+import { loginPage } from '#tests/playwright-utils.ts'
+import { expect, test } from './baseTest.ts'
 
 test('Users can add 2FA to their account and use it when logging in', async ({
 	page,
+	insertUser,
 }) => {
 	const password = faker.internet.password()
-	const user = await insertNewUser({ password })
-	await loginPage({ page, user })
+	const user = await insertUser({ password })
+	await loginPage({ page, user, insertUser })
 	await page.goto('/settings/profile')
 
 	await page.getByRole('link', { name: /enable 2fa/i }).click()

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -1,0 +1,39 @@
+import { test as base } from '@playwright/test'
+import { getPasswordHash } from '#app/utils/auth.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { createUser } from '#tests/db-utils.ts'
+
+export { expect } from '@playwright/test'
+
+export const test = base.extend<{
+	insertUser: (user?: {
+		username?: string
+		password?: string
+		email?: string
+	}) => Promise<{ id: string; username: string; name: string; email: string }>
+}>({
+	insertUser: async ({}, use) => {
+		const insertedUsers = new Set<string>()
+		await use(async ({ username, email, password } = {}) => {
+			const userData = createUser()
+			username ??= userData.username
+			password ??= userData.username
+			email ??= userData.email
+			const user = await prisma.user.create({
+				select: { id: true, name: true, username: true, email: true },
+				data: {
+					...userData,
+					email,
+					username,
+					roles: { connect: { name: 'user' } },
+					password: { create: { hash: await getPasswordHash(password) } },
+				},
+			})
+			insertedUsers.add(user.id)
+			return user as typeof user & { name: string }
+		})
+		await prisma.user.deleteMany({
+			where: { id: { in: Array.from(insertedUsers) } },
+		})
+	},
+})

--- a/tests/e2e/notes.test.ts
+++ b/tests/e2e/notes.test.ts
@@ -1,10 +1,10 @@
 import { faker } from '@faker-js/faker'
-import { expect, test } from '@playwright/test'
 import { prisma } from '#app/utils/db.server.ts'
 import { loginPage } from '#tests/playwright-utils.ts'
+import { expect, test } from './baseTest.ts'
 
-test('Users can create notes', async ({ page }) => {
-	const user = await loginPage({ page })
+test('Users can create notes', async ({ page, insertUser }) => {
+	const user = await loginPage({ page, insertUser })
 	await page.goto(`/users/${user.username}/notes`)
 
 	const newNote = createNote()
@@ -18,8 +18,8 @@ test('Users can create notes', async ({ page }) => {
 	await expect(page).toHaveURL(new RegExp(`/users/${user.username}/notes/.*`))
 })
 
-test('Users can edit notes', async ({ page }) => {
-	const user = await loginPage({ page })
+test('Users can edit notes', async ({ page, insertUser }) => {
+	const user = await loginPage({ page, insertUser })
 
 	const note = await prisma.note.create({
 		select: { id: true },
@@ -42,8 +42,8 @@ test('Users can edit notes', async ({ page }) => {
 	).toBeVisible()
 })
 
-test('Users can delete notes', async ({ page }) => {
-	const user = await loginPage({ page })
+test('Users can delete notes', async ({ page, insertUser }) => {
+	const user = await loginPage({ page, insertUser })
 
 	const note = await prisma.note.create({
 		select: { id: true },

--- a/tests/e2e/search.test.ts
+++ b/tests/e2e/search.test.ts
@@ -1,8 +1,7 @@
-import { expect, test } from '@playwright/test'
-import { insertNewUser } from '#tests/playwright-utils.ts'
+import { expect, test } from './baseTest.ts'
 
-test('Search from home page', async ({ page }) => {
-	const newUser = await insertNewUser()
+test('Search from home page', async ({ page, insertUser }) => {
+	const newUser = await insertUser()
 	await page.goto('/')
 
 	await page.getByRole('searchbox', { name: /search/i }).fill(newUser.username)

--- a/tests/e2e/settings-profile.test.ts
+++ b/tests/e2e/settings-profile.test.ts
@@ -1,18 +1,13 @@
 import { faker } from '@faker-js/faker'
-import { expect, test } from '@playwright/test'
 import { verifyUserPassword } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariant } from '#app/utils/misc.tsx'
 import { readEmail } from '#tests/mocks/utils.ts'
-import {
-	createUser,
-	insertNewUser,
-	loginPage,
-	waitFor,
-} from '#tests/playwright-utils.ts'
+import { createUser, loginPage, waitFor } from '#tests/playwright-utils.ts'
+import { expect, test } from './baseTest.ts'
 
-test('Users can update their basic info', async ({ page }) => {
-	await loginPage({ page })
+test('Users can update their basic info', async ({ page, insertUser }) => {
+	await loginPage({ page, insertUser })
 	await page.goto('/settings/profile')
 
 	const newUserData = createUser()
@@ -25,11 +20,11 @@ test('Users can update their basic info', async ({ page }) => {
 	await page.getByRole('button', { name: /^save/i }).click()
 })
 
-test('Users can update their password', async ({ page }) => {
+test('Users can update their password', async ({ page, insertUser }) => {
 	const oldPassword = faker.internet.password()
 	const newPassword = faker.internet.password()
-	const user = await insertNewUser({ password: oldPassword })
-	await loginPage({ page, user })
+	const user = await insertUser({ password: oldPassword })
+	await loginPage({ page, user, insertUser })
 	await page.goto('/settings/profile')
 
 	await page.getByRole('link', { name: /change password/i }).click()
@@ -57,8 +52,8 @@ test('Users can update their password', async ({ page }) => {
 	).toEqual({ id: user.id })
 })
 
-test('Users can update their profile photo', async ({ page }) => {
-	const user = await loginPage({ page })
+test('Users can update their profile photo', async ({ page, insertUser }) => {
+	const user = await loginPage({ page, insertUser })
 	await page.goto('/settings/profile')
 
 	const beforeSrc = await page
@@ -87,8 +82,8 @@ test('Users can update their profile photo', async ({ page }) => {
 	expect(beforeSrc).not.toEqual(afterSrc)
 })
 
-test('Users can change their email address', async ({ page }) => {
-	const preUpdateUser = await loginPage({ page })
+test('Users can change their email address', async ({ page, insertUser }) => {
+	const preUpdateUser = await loginPage({ page, insertUser })
 	const newEmailAddress = faker.internet.email().toLowerCase()
 	expect(preUpdateUser.email).not.toEqual(newEmailAddress)
 	await page.goto('/settings/profile')


### PR DESCRIPTION
Hi Kent!

This is a PR regarding your recently filed issue in https://github.com/microsoft/playwright/issues/27058. We at Playwright recommend fixtures for the cleanup of resources, which make it super easy to cleanup things after the use. In this PR I moved some of your resources over to fixtures, so its a bit move obvious to you to understand what we described in the issue, let me know if you have any questions!

I saw your `UniqueEnforcer` instance, this might be problematic, since it does not sync across multiple Playwright workers. Also it might make sense to move `loginPage` over to a fixture, so it always has access to the `page` instance. Not sure about the design choices about the `User` type, I just created it for now, might be changed to type inference etc. later.

(Marked as a draft for now, since this is more a FYI / how we would do things PR)

