### PR TITLE
Install packages with bun in github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,11 @@ jobs:
         with:
           node-version: 18
 
+      - name: 🍞 Install Bun
+        uses: oven-sh/setup-bun@v1
+
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+        run: bun install
 
       - name: 🖼 Build icons
         run: npm run build:icons
@@ -48,8 +51,14 @@ jobs:
         with:
           node-version: 18
 
+      - name: 🍞 Install Bun
+        uses: oven-sh/setup-bun@v1
+
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+        run: bun install
+
+      - name: 🧰 Generate Prisma Client
+        run: npx prisma generate
 
       - name: 🖼 Build icons
         run: npm run build:icons
@@ -69,8 +78,14 @@ jobs:
         with:
           node-version: 18
 
+      - name: 🍞 Install Bun
+        uses: oven-sh/setup-bun@v1
+
       - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
+        run: bun install
+
+      - name: 🧰 Generate Prisma Client
+        run: npx prisma generate
 
       - name: 🏄 Copy test env vars
         run: cp .env.example .env

--- a/app/routes/_auth+/auth.$provider.callback.test.ts
+++ b/app/routes/_auth+/auth.$provider.callback.test.ts
@@ -193,12 +193,15 @@ test('if a user is not logged in, but the connection exists and they have enable
 			userId,
 		},
 	})
-	const { otp: _otp, ...config } = generateTOTP()
+	const { secret, period, digits, algorithm } = generateTOTP()
 	await prisma.verification.create({
 		data: {
-			type: twoFAVerificationType,
+			algorithm,
+			digits,
+			period,
+			secret,
 			target: userId,
-			...config,
+			type: twoFAVerificationType,
 		},
 	})
 	const request = await setupRequest({ code: githubUser.code })

--- a/app/routes/_auth+/verify.tsx
+++ b/app/routes/_auth+/verify.tsx
@@ -115,15 +115,19 @@ export async function prepareVerification({
 	const verifyUrl = getRedirectToUrl({ request, type, target })
 	const redirectTo = new URL(verifyUrl.toString())
 
-	const { otp, ...verificationConfig } = generateTOTP({
-		algorithm: 'SHA256',
+	const algorithm = 'SHA256'
+	const { digits, otp, secret, ...verificationConfig } = generateTOTP({
+		algorithm,
 		period,
 	})
 	const verificationData = {
-		type,
-		target,
-		...verificationConfig,
+		algorithm,
+		digits,
 		expiresAt: new Date(Date.now() + verificationConfig.period * 1000),
+		period,
+		secret,
+		target,
+		type,
 	}
 	await prisma.verification.upsert({
 		where: { target_type: { target, type } },

--- a/app/routes/settings+/profile.two-factor.index.tsx
+++ b/app/routes/settings+/profile.two-factor.index.tsx
@@ -19,11 +19,14 @@ export async function loader({ request }: DataFunctionArgs) {
 
 export async function action({ request }: DataFunctionArgs) {
 	const userId = await requireUserId(request)
-	const { otp: _otp, ...config } = generateTOTP()
+	const { algorithm, digits, period, secret } = generateTOTP()
 	const verificationData = {
-		...config,
-		type: twoFAVerifyVerificationType,
+		algorithm,
+		digits,
+		period,
+		secret,
 		target: userId,
+		type: twoFAVerifyVerificationType,
 	}
 	await prisma.verification.upsert({
 		where: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,5 @@
-/// <reference types="vitest" />
-
 import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
 	// @ts-expect-error their types are wrong


### PR DESCRIPTION
(deploy.yml): Swap out npm with bun for faster package installation in the lint, typecheck, and vitest GitHub actions. Unable to swap out npm for bun in the playwright job due to a compatibility issue with better-sqlite3.

(vitest.config.ts): Replaced the defineConfig 'vite' import with the 'vitest/config' import because of a type issue that occurs when using bun with vite.

(auth..callback.test.ts, verify.tsx): Explicitly de-structured properties from generateTOTP because 'charSet' doesn't exists in the verification table but was appearing in '...config'.

## Test Plan

To ensure that the transition from NPM to Bun in the GitHub Actions workflow is successful, follow these steps:
1. Trigger a workflow run (either by pushing changes or creating a pull request to main/dev branches).
2. Monitor the GitHub Actions logs to verify that Bun is being installed and used without errors.
3. Check the individual jobs (lint, typecheck, vitest, playwright) in the workflow to ensure all steps are executed correctly.
4. Ensure that all the tests and checks pass without any errors.
5. After the tests, verify that any generated reports or logs (like the playwright report) are uploaded correctly.

## Checklist

- Bun is installed without any issues.
- Dependencies are downloaded using Bun.
- Scripts are executed with Bun without errors (like building icons, linting, type checking, etc.).
- Tests (vitest, playwright) are running and completing successfully.
- Playwright report is uploaded to the GitHub artifacts.
