### PR TITLE
Update chokidar to watch version.txt

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -13,7 +13,6 @@ import {
 import { wrapExpressCreateRequestHandler } from '@sentry/remix'
 import address from 'address'
 import chalk from 'chalk'
-import chokidar from 'chokidar'
 import closeWithGrace from 'close-with-grace'
 import compression from 'compression'
 import express from 'express'
@@ -21,10 +20,6 @@ import rateLimit from 'express-rate-limit'
 import getPort, { portNumbers } from 'get-port'
 import helmet from 'helmet'
 import morgan from 'morgan'
-
-// @ts-ignore - this file may not exist if you haven't built yet, but it will
-// definitely exist by the time the dev or prod server actually runs.
-import * as remixBuild from '#build/index.js'
 
 installGlobals()
 
@@ -35,8 +30,13 @@ const createRequestHandler = wrapExpressCreateRequestHandler(
 )
 
 const BUILD_PATH = '../build/index.js'
+const WATCH_PATH = '../build/version.txt'
 
-const build = remixBuild as unknown as ServerBuild
+/**
+ * Initial build
+ * @type {ServerBuild}
+ */
+const build = await import(BUILD_PATH)
 let devBuild = build
 
 const app = express()
@@ -262,8 +262,14 @@ if (MODE === 'development') {
 		broadcastDevReady(devBuild)
 	}
 
+	// We'll import chokidar here so doesn't get bundled in production.
+	const chokidar = await import('chokidar')
+
 	const dirname = path.dirname(fileURLToPath(import.meta.url))
-	const watchPath = path.join(dirname, BUILD_PATH).replace(/\\/g, '/')
-	const watcher = chokidar.watch(watchPath, { ignoreInitial: true })
-	watcher.on('all', reloadBuild)
+	const watchPath = path.join(dirname, WATCH_PATH).replace(/\\/g, '/')
+
+	chokidar
+		.watch(watchPath, { ignoreInitial: true })
+		.on('add', reloadBuild)
+		.on('change', reloadBuild)
 }


### PR DESCRIPTION
Update chokidar to resolve a rare race condition issue that resultant in dev server crashing. This PR https://github.com/remix-run/remix/pull/7299 sets up a fix where we can watch the version.txt file for changes (rather than build/index.js directly) to avoid race condition.


## Test Plan

This affects dev server behavior only.

## Checklist

- [x] Tests updated
- [x] Docs updated

## Screenshots

In some rare circumstances, the current chokidar watch setup could result in the following error:

```console
/.../node_modules/@remix-run/server-runtime/dist/dev.js:26
      buildHash: build.assets.version
                              ^
TypeError: Cannot read properties of undefined (reading 'version')
    at Object.broadcastDevReady (/.../node_modules/@remix-run/server-runtime/dist/dev.js:26:31)
    at FSWatcher.handleServerUpdate (/.../node_modules/@remix-run/serve/dist/cli.js:74:12)
```

We sidesteped this race condition issue by introducing a new file in Remix v2, version.txt, that only gets updated after the build completes.

## References

* https://github.com/remix-run/remix/issues/6919
* https://github.com/remix-run/remix/pull/7299
* https://github.com/xHomu/remix-v2-server/blob/main/server.ts
