### PR TITLE
Removed --typescript flag, in remix v2 it is used as name for the directory

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ Stack, run the following [`npx`](https://docs.npmjs.com/cli/v9/commands/npx)
 command:
 
 ```sh
-npx create-remix@latest --typescript --install --template epicweb-dev/epic-stack
+npx create-remix@latest --install --template epicweb-dev/epic-stack
 ```
 
 This will prompt you for a project name (the name of the directory to put your


### PR DESCRIPTION
removed --typscriot flag because it is used as directory name with new remix version 2

<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [x] Tests updated
- [x] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
