### PR TITLE
fix(entry.server): provide nonce to react scripts

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -72,6 +72,7 @@ export default async function handleRequest(...args: DocRequestArgs) {
 
 					console.error(error)
 				},
+				nonce,
 			},
 		)
 


### PR DESCRIPTION
This patch provides the `nonce` option to the React `renderToPipeableStream` function so that React will add it to scripts dynamically injected (e.g. the `<Suspense>` inline scripts).

Ref: https://react.dev/reference/react-dom/server/renderToPipeableStream#parameters
Ref: https://github.com/facebook/react/issues/26026#issuecomment-1398640424
Ref: https://github.com/remix-run/remix/issues/5156#issuecomment-1397935995

<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
