### PR TITLE
docs: fix cli param

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </div>
 
 ```sh
-npx create-remix@latest --install --init --git-init --template epicweb-dev/epic-stack
+npx create-remix@latest --install --init-script --git-init --template epicweb-dev/epic-stack
 ```
 
 [![The Epic Stack](https://github-production-user-asset-6210df.s3.amazonaws.com/1500684/246885449-1b00286c-aa3d-44b2-9ef2-04f694eb3592.png)](https://www.epicweb.dev/epic-stack)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ Stack, run the following [`npx`](https://docs.npmjs.com/cli/v9/commands/npx)
 command:
 
 ```sh
-npx create-remix@latest --install --init --git-init --template epicweb-dev/epic-stack
+npx create-remix@latest --install --init-script --git-init --template epicweb-dev/epic-stack
 ```
 
 This will prompt you for a project name (the name of the directory to put your


### PR DESCRIPTION
`--init` is not a valid option for `create-remix`.

Launching the script as it is now, the CLI will pick up `--init` as the folder name to use to create the project, and won't ask for one.

If the intention was to automatically launch the remix.init script, we should use `--init-script` instead.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

~~- [ ] Tests updated~~
- [x] Docs updated