### PR TITLE
add epic stack monorepo example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -59,6 +59,8 @@ This page links to examples of how to implement some things with the Epic Stack.
   [@rperon](https://github.com/rperon): An example of the Epic Stack with i18n
   using [i18next](https://www.i18next.com/) and
   [remix-18next](https://github.com/sergiodxa/remix-i18next)
+- [Epic Stack monorepo with pnpm + turbo](https://github.com/PhilDL/epic-stack-monorepo):
+  An example of the Epic Stack in a monorepo setup, configs packages, UI package, and "client-hints" example package.
 
 ## How to contribute
 


### PR DESCRIPTION
## Add monorepo example

This is a monorepo was created with `pnpm` for space efficiency and conveniences when working with workspaces. 
On top of that package manager the monorepo pipeline tool of choice is turborepo (feel free to switch it for NX).

- `apps` Folder containing the applications
  - [`epic-app`](https://github.com/PhilDL/epic-stack-monorepo/tree/main/apps/epic-app):
    the [Remix.run](https://remix.run) Epic Stack app.
- `packages` Folder containing examples

  - [`ui`](https://github.com/PhilDL/epic-stack-monorepo/tree/main/packages/ui):
    this UI package contains the [shadcn/ui](https://ui.shadcn.com/) Component
    previously in the Epic Stack App. It also exposes a Tailwind config
    "epic-stack" preset, that you consume from the Remix app.
  - [`client-hints`](https://github.com/PhilDL/epic-stack-monorepo/tree/main/packages/client-hints):
    is an example package that takes the original functions and hooks handling
    client-hints in the `utils` folder of the original app, and put that into
    their own package.
    [`The hooks`](https://github.com/PhilDL/epic-stack-monorepo/tree/main/packages/client-hints/src/client-hints.tsx):
    were refactored to take "loader" as generics (typically the root loader).
  - Some config packages:
    - eslint containing some common eslint configs.
    - tsconfig presets.

## Checklist

- [x] Tests updated
- [x] Docs updated

## Screenshots

The repo has a short commit history to allow folks to pick the part that interest them.

![CleanShot 2023-09-23 at 14 58 27](https://github.com/epicweb-dev/epic-stack/assets/4941205/e30c69d8-7155-4eaf-802e-9fa653a28d93)

The Dockerfile + fly setup is working and live [https://epic-stack-monorepo.fly.dev/](https://epic-stack-monorepo.fly.dev/)
