### PR TITLE
Create utility to clean up the entire database

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker'
 import { promiseHash } from 'remix-utils'
 import { prisma } from '#app/utils/db.server.ts'
 import {
+	cleanupDb,
 	createPassword,
 	createUser,
 	getNoteImages,
@@ -15,10 +16,7 @@ async function seed() {
 	console.time(`🌱 Database has been seeded`)
 
 	console.time('🧹 Cleaned up the database...')
-	await prisma.user.deleteMany()
-	await prisma.verification.deleteMany()
-	await prisma.role.deleteMany()
-	await prisma.permission.deleteMany()
+	await cleanupDb(prisma)
 	console.timeEnd('🧹 Cleaned up the database...')
 
 	console.time('🔑 Created permissions...')

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import { faker } from '@faker-js/faker'
 import bcrypt from 'bcryptjs'
 import { UniqueEnforcer } from 'enforce-unique'
+import { PrismaClient } from '@prisma/client'
 
 const uniqueUsernameEnforcer = new UniqueEnforcer()
 
@@ -112,4 +113,20 @@ export async function img({
 		contentType: filepath.endsWith('.png') ? 'image/png' : 'image/jpeg',
 		blob: await fs.promises.readFile(filepath),
 	}
+}
+
+export async function cleanupDb(prisma: PrismaClient) {
+	const tables = await prisma.$queryRaw<
+		{ name: string }[]
+	>`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations';`
+
+	await prisma.$transaction([
+		// Disable FK constraints to avoid relation conflicts during deletion
+		prisma.$executeRawUnsafe(`PRAGMA foreign_keys = OFF`),
+		// Delete all rows from each table, preserving table structures
+		...tables.map(({ name }) =>
+			prisma.$executeRawUnsafe(`DELETE from "${name}"`),
+		),
+		prisma.$executeRawUnsafe(`PRAGMA foreign_keys = ON`),
+	])
 }

--- a/tests/setup/db-setup.ts
+++ b/tests/setup/db-setup.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import fsExtra from 'fs-extra'
 import { afterAll, afterEach, beforeAll } from 'vitest'
 import { BASE_DATABASE_PATH } from './global-setup.ts'
+import { cleanupDb } from '#tests/db-utils.ts'
 
 const databaseFile = `./tests/prisma/data.${process.env.VITEST_POOL_ID || 0}.db`
 const databasePath = path.join(process.cwd(), databaseFile)
@@ -12,13 +13,10 @@ beforeAll(async () => {
 })
 
 // we *must* use dynamic imports here so the process.env.DATABASE_URL is set
-// befor prisma is imported and initialized
+// before prisma is imported and initialized
 afterEach(async () => {
 	const { prisma } = await import('#app/utils/db.server.ts')
-	await prisma.user.deleteMany()
-	await prisma.verification.deleteMany()
-	await prisma.role.deleteMany()
-	await prisma.permission.deleteMany()
+	await cleanupDb(prisma)
 })
 
 afterAll(async () => {


### PR DESCRIPTION
The code to clean the database was duplicated between vitest and the seeding script, and not entirely complete. 

Deleting all rows in a database can easily cause relation conflicts if you do it in the wrong order. So I used some raw sql to avoid those problems and make it fast as possible.

On my machine it takes around 8ms to clean the entire seeded database:

```
11:01:58.890Z prisma:query - 0ms - SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations'; 
11:01:58.892Z prisma:query - 0ms - BEGIN 
11:01:58.892Z prisma:query - 0ms - PRAGMA foreign_keys = OFF 
11:01:58.896Z prisma:query - 3ms - DELETE from "User" 
11:01:58.896Z prisma:query - 0ms - DELETE from "Note" 
11:01:58.896Z prisma:query - 0ms - DELETE from "NoteImage" 
11:01:58.896Z prisma:query - 0ms - DELETE from "UserImage" 
11:01:58.896Z prisma:query - 0ms - DELETE from "Password" 
11:01:58.896Z prisma:query - 0ms - DELETE from "Session" 
11:01:58.896Z prisma:query - 0ms - DELETE from "Permission" 
11:01:58.896Z prisma:query - 0ms - DELETE from "Role" 
11:01:58.897Z prisma:query - 0ms - DELETE from "Verification" 
11:01:58.897Z prisma:query - 0ms - DELETE from "Connection" 
11:01:58.897Z prisma:query - 0ms - DELETE from "_PermissionToRole" 
11:01:58.897Z prisma:query - 0ms - DELETE from "_RoleToUser" 
11:01:58.897Z prisma:query - 0ms - PRAGMA foreign_keys = ON 
11:01:58.897Z prisma:query - 1ms - COMMIT 
🧹 Cleaned up the database...: 8.728ms
```

## Test Plan

I tested it manually as it a test utility.

## Checklist

- [ ] Tests updated
- [ ] Docs updated

