### PR TITLE
Fix busy resource error in test's afterAll

### DIFF
--- a/tests/setup/db-setup.ts
+++ b/tests/setup/db-setup.ts
@@ -21,6 +21,6 @@ afterEach(async () => {
 
 afterAll(async () => {
 	const { prisma } = await import('#app/utils/db.server.ts')
-	prisma.$disconnect()
+	await prisma.$disconnect()
 	await fsExtra.remove(databasePath)
 })


### PR DESCRIPTION
Fix the `Error: EBUSY: resource busy or locked, unlink 'hidden\path\tests\prisma\data.25504.db'` that occurs on Windows during the `afterAll` call in tests.

Related Issue: https://github.com/epicweb-dev/epic-stack/issues/423#issuecomment-1752018535

## Test Plan

- Ensure you're in a Windows environment
- Run `vitest --no-threads` ([ref issue](https://github.com/epicweb-dev/epic-stack/issues/423#issuecomment-1752017026) explaining why to use --no-threads)
- All tests pass & no `Error: EBUSY: resource busy or locked` for every `.db` created in `tests/prisma/`
