### PR TITLE
Add passkeys / webauthn example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -64,6 +64,10 @@ This page links to examples of how to implement some things with the Epic Stack.
   with [Argos](https://www.argos-ci.com/) for visual testing
 - [Epic Stack monorepo with pnpm + turbo](https://github.com/PhilDL/epic-stack-monorepo):
   An example of the Epic Stack in a monorepo setup, configs packages, UI package, and "client-hints" example package.
+- [Epic Stack + passkeys/webauthn](https://github.com/rperon/epic-stack-with-passkeys/) by
+  [@rperon](https://github.com/rperon): An example of the Epic Stack with passkeys
+  using [remix-auth-webauthn](https://github.com/alexanderson1993/remix-auth-webauthn) and 
+  [remix-auth](https://npm.im/remix-auth).
 
 ## How to contribute
 


### PR DESCRIPTION
Example for Passkeys / webauthn support in the epic stack using [remix-auth-webauthn](https://github.com/alexanderson1993/remix-auth-webauthn). 

With this stack, you can register and login with a passkey.

Should fix #448 

## Screenshots

<img width="643" alt="passkey" src="https://github.com/epicweb-dev/epic-stack/assets/692098/dcbb9a10-dff9-4a3d-9200-7db3923109ca">
