### PR TITLE
Upgrade remix-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "remix-auth": "^3.5.1",
         "remix-auth-form": "^1.3.0",
         "remix-auth-github": "^1.6.0",
-        "remix-utils": "^7.0.2",
+        "remix-utils": "^7.1.0",
         "set-cookie-parser": "^2.6.0",
         "sonner": "^1.0.3",
         "source-map-support": "^0.5.21",
@@ -15522,9 +15522,9 @@
       }
     },
     "node_modules/remix-utils": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/remix-utils/-/remix-utils-7.0.2.tgz",
-      "integrity": "sha512-BsGmOgUzbT+Ui0hlWe5XR37N/MAbOSRyKBkxs8yckU+VOCzIuSRiOPk6qK+Hch4F18QSMRm/5IlrsROtrM1l2A==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/remix-utils/-/remix-utils-7.1.0.tgz",
+      "integrity": "sha512-cceintceWvmNvgLLFeAUkWRcdWuOHGDLaWh0aeL0bLGWnMPBilIyT74Rira1az/ImS9owfh8tjLL4w/22AXJiA==",
       "dependencies": {
         "type-fest": "^4.3.3"
       },

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "remix-auth": "^3.5.1",
     "remix-auth-form": "^1.3.0",
     "remix-auth-github": "^1.6.0",
-    "remix-utils": "^7.0.2",
+    "remix-utils": "^7.1.0",
     "set-cookie-parser": "^2.6.0",
     "sonner": "^1.0.3",
     "source-map-support": "^0.5.21",


### PR DESCRIPTION
This update fixes the [Honeypot Input bug](https://github.com/sergiodxa/remix-utils/commit/d3f8e818bb9a06ca1f655d1a4735cdccdf2f1910).

## Screenshots

<img width="411" alt="Capture d’écran 2023-10-14 à 19 26 58" src="https://github.com/epicweb-dev/epic-stack/assets/64654633/1573db3f-2b05-4930-84ea-712791a00257">
