### PR TITLE
Bump tsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,7 @@
         "vitest": "^0.34.5"
       },
       "engines": {
-        "node": "^18 || ^20"
+        "node": "18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,7 @@
         "prettier-plugin-sql": "^0.15.1",
         "prettier-plugin-tailwindcss": "^0.5.4",
         "remix-flat-routes": "^0.5.11",
-        "tsx": "^3.13.0",
+        "tsx": "^3.14.0",
         "typescript": "^5.2.2",
         "vite": "^4.4.9",
         "vitest": "^0.34.5"
@@ -17362,9 +17362,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tsx": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.13.0.tgz",
-      "integrity": "sha512-rjmRpTu3as/5fjNq/kOkOtihgLxuIz6pbKdj9xwP4J5jOLkBxw/rjN5ANw+KyrrOXV5uB7HC8+SrrSJxT65y+A==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.14.0.tgz",
+      "integrity": "sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==",
       "dev": true,
       "dependencies": {
         "esbuild": "~0.18.20",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "prettier-plugin-sql": "^0.15.1",
     "prettier-plugin-tailwindcss": "^0.5.4",
     "remix-flat-routes": "^0.5.11",
-    "tsx": "^3.13.0",
+    "tsx": "^3.14.0",
     "typescript": "^5.2.2",
     "vite": "^4.4.9",
     "vitest": "^0.34.5"

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "vitest": "^0.34.5"
   },
   "engines": {
-    "node": "^18 || ^20"
+    "node": "18"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "vitest": "^0.34.5"
   },
   "engines": {
-    "node": "18"
+    "node": "^18 || ^20"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"


### PR DESCRIPTION
Get rid of the --experimental-loader warning from node when using `tsx`:

<img width="1028" alt="image" src="https://github.com/epicweb-dev/epic-stack/assets/84349818/8e04c9c4-167d-4941-8dc3-bc7318427b9b">

 See https://github.com/esbuild-kit/tsx/issues/330
