### PR TITLE
Increase prettier printWidth to 100 (except for md files)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,11 +4,7 @@ const appFiles = ['app/**']
 
 /** @type {import('@types/eslint').Linter.BaseConfig} */
 module.exports = {
-	extends: [
-		'@remix-run/eslint-config',
-		'@remix-run/eslint-config/node',
-		'prettier',
-	],
+	extends: ['@remix-run/eslint-config', '@remix-run/eslint-config/node', 'prettier'],
 	rules: {
 		// playwright requires destructuring in fixtures even if you don't use anything 🤷‍♂️
 		'no-empty-pattern': 'off',
@@ -26,14 +22,7 @@ module.exports = {
 			'warn',
 			{
 				alphabetize: { order: 'asc', caseInsensitive: true },
-				groups: [
-					'builtin',
-					'external',
-					'internal',
-					'parent',
-					'sibling',
-					'index',
-				],
+				groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
 			},
 		],
 	},
@@ -47,10 +36,7 @@ module.exports = {
 				'remix-react-routes/require-valid-paths': 'error',
 				// disable this one because it doesn't appear to work with our
 				// route convention. Someone should dig deeper into this...
-				'remix-react-routes/no-relative-paths': [
-					'off',
-					{ allowLinksToSelf: true },
-				],
+				'remix-react-routes/no-relative-paths': ['off', { allowLinksToSelf: true }],
 				'remix-react-routes/no-urls': 'error',
 				'no-restricted-imports': [
 					'error',

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,9 +112,8 @@ jobs:
         with:
           path: prisma/data.db
           key:
-            db-cache-schema_${{ hashFiles('./prisma/schema.prisma')
-            }}-migrations_${{ hashFiles('./prisma/migrations/*/migration.sql')
-            }}
+            db-cache-schema_${{ hashFiles('./prisma/schema.prisma') }}-migrations_${{
+            hashFiles('./prisma/migrations/*/migration.sql') }}
 
       - name: 🌱 Seed Database
         if: steps.db-cache.outputs.cache-hit != 'true'
@@ -142,8 +141,8 @@ jobs:
     needs: [lint, typecheck, vitest, playwright]
     # only build/deploy main branch on pushes
     if:
-      ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') &&
-      github.event_name == 'push' }}
+      ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name
+      == 'push' }}
 
     steps:
       - name: ⬇️ Checkout repo
@@ -168,14 +167,13 @@ jobs:
       - name: 🚀 Deploy Staging
         if: ${{ github.ref == 'refs/heads/dev' }}
         run:
-          flyctl deploy --remote-only --build-arg COMMIT_SHA=${{ github.sha }}
-          --app ${{ steps.app_name.outputs.value }}-staging
+          flyctl deploy --remote-only --build-arg COMMIT_SHA=${{ github.sha }} --app ${{
+          steps.app_name.outputs.value }}-staging
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: 🚀 Deploy Production
         if: ${{ github.ref == 'refs/heads/main' }}
-        run:
-          flyctl deploy --remote-only --build-arg COMMIT_SHA=${{ github.sha }}
+        run: flyctl deploy --remote-only --build-arg COMMIT_SHA=${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -8,7 +8,7 @@ export default {
 	htmlWhitespaceSensitivity: 'css',
 	insertPragma: false,
 	jsxSingleQuote: false,
-	printWidth: 80,
+	printWidth: 100,
 	proseWrap: 'always',
 	quoteProps: 'as-needed',
 	requirePragma: false,
@@ -23,6 +23,12 @@ export default {
 			files: ['**/*.json'],
 			options: {
 				useTabs: false,
+			},
+		},
+		{
+			files: ['**/*.md'],
+			options: {
+				printWidth: 80,
 			},
 		},
 	],

--- a/app/components/forms.tsx
+++ b/app/components/forms.tsx
@@ -7,19 +7,13 @@ import { Textarea } from './ui/textarea.tsx'
 
 export type ListOfErrors = Array<string | null | undefined> | null | undefined
 
-export function ErrorList({
-	id,
-	errors,
-}: {
-	errors?: ListOfErrors
-	id?: string
-}) {
+export function ErrorList({ id, errors }: { errors?: ListOfErrors; id?: string }) {
 	const errorsToRender = errors?.filter(Boolean)
 	if (!errorsToRender?.length) return null
 	return (
 		<ul id={id} className="flex flex-col gap-1">
 			{errorsToRender.map(e => (
-				<li key={e} className="text-foreground-destructive text-[10px]">
+				<li key={e} className="text-[10px] text-foreground-destructive">
 					{e}
 				</li>
 			))}
@@ -105,8 +99,7 @@ export function CheckboxField({
 	const control = useInputEvent({
 		// Retrieve the checkbox element by name instead as Radix does not expose the internal checkbox element
 		// See https://github.com/radix-ui/primitives/discussions/874
-		ref: () =>
-			buttonRef.current?.form?.elements.namedItem(buttonProps.name ?? ''),
+		ref: () => buttonRef.current?.form?.elements.namedItem(buttonProps.name ?? ''),
 		onFocus: () => buttonRef.current?.focus(),
 	})
 	const id = buttonProps.id ?? buttonProps.name ?? fallbackId

--- a/app/components/progress-bar.tsx
+++ b/app/components/progress-bar.tsx
@@ -18,9 +18,7 @@ function EpicProgress() {
 		if (!ref.current) return
 		if (delayedPending) setAnimationComplete(false)
 
-		const animationPromises = ref.current
-			.getAnimations()
-			.map(({ finished }) => finished)
+		const animationPromises = ref.current.getAnimations().map(({ finished }) => finished)
 
 		Promise.allSettled(animationPromises).then(() => {
 			if (!delayedPending) setAnimationComplete(true)
@@ -39,21 +37,14 @@ function EpicProgress() {
 				className={cn(
 					'h-full w-0 bg-foreground duration-500 ease-in-out',
 					transition.state === 'idle' &&
-						(animationComplete
-							? 'transition-none'
-							: 'w-full opacity-0 transition-all'),
+						(animationComplete ? 'transition-none' : 'w-full opacity-0 transition-all'),
 					delayedPending && transition.state === 'submitting' && 'w-5/12',
 					delayedPending && transition.state === 'loading' && 'w-8/12',
 				)}
 			/>
 			{delayedPending && (
 				<div className="absolute flex items-center justify-center">
-					<Icon
-						name="update"
-						size="md"
-						className="m-1 animate-spin text-foreground"
-						aria-hidden
-					/>
+					<Icon name="update" size="md" className="m-1 animate-spin text-foreground" aria-hidden />
 				</div>
 			)}
 		</div>

--- a/app/components/spacer.tsx
+++ b/app/components/spacer.tsx
@@ -26,18 +26,7 @@ export function Spacer({
 	 *
 	 * 4xl: h-44 (176px)
 	 */
-	size:
-		| '4xs'
-		| '3xs'
-		| '2xs'
-		| 'xs'
-		| 'sm'
-		| 'md'
-		| 'lg'
-		| 'xl'
-		| '2xl'
-		| '3xl'
-		| '4xl'
+	size: '4xs' | '3xs' | '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl'
 }) {
 	const options: Record<typeof size, string> = {
 		'4xs': 'h-4',

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -10,12 +10,9 @@ const buttonVariants = cva(
 		variants: {
 			variant: {
 				default: 'bg-primary text-primary-foreground hover:bg-primary/80',
-				destructive:
-					'bg-destructive text-destructive-foreground hover:bg-destructive/80',
-				outline:
-					'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
-				secondary:
-					'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+				destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/80',
+				outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+				secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
 				ghost: 'hover:bg-accent hover:text-accent-foreground',
 				link: 'text-primary underline-offset-4 hover:underline',
 			},
@@ -45,11 +42,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 	({ className, variant, size, asChild = false, ...props }, ref) => {
 		const Comp = asChild ? Slot : 'button'
 		return (
-			<Comp
-				className={cn(buttonVariants({ variant, size, className }))}
-				ref={ref}
-				{...props}
-			/>
+			<Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
 		)
 	},
 )

--- a/app/components/ui/checkbox.tsx
+++ b/app/components/ui/checkbox.tsx
@@ -22,16 +22,9 @@ const Checkbox = React.forwardRef<
 		)}
 		{...props}
 	>
-		<CheckboxPrimitive.Indicator
-			className={cn('flex items-center justify-center text-current')}
-		>
+		<CheckboxPrimitive.Indicator className={cn('flex items-center justify-center text-current')}>
 			<svg viewBox="0 0 8 8">
-				<path
-					d="M1,4 L3,6 L7,2"
-					stroke="currentcolor"
-					strokeWidth="1"
-					fill="none"
-				/>
+				<path d="M1,4 L3,6 L7,2" stroke="currentcolor" strokeWidth="1" fill="none" />
 			</svg>
 		</CheckboxPrimitive.Indicator>
 	</CheckboxPrimitive.Root>

--- a/app/components/ui/dropdown-menu.tsx
+++ b/app/components/ui/dropdown-menu.tsx
@@ -34,8 +34,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
 		<span className="ml-auto h-4 w-4">▶️</span>
 	</DropdownMenuPrimitive.SubTrigger>
 ))
-DropdownMenuSubTrigger.displayName =
-	DropdownMenuPrimitive.SubTrigger.displayName
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName
 
 const DropdownMenuSubContent = React.forwardRef<
 	React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
@@ -50,8 +49,7 @@ const DropdownMenuSubContent = React.forwardRef<
 		{...props}
 	/>
 ))
-DropdownMenuSubContent.displayName =
-	DropdownMenuPrimitive.SubContent.displayName
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName
 
 const DropdownMenuContent = React.forwardRef<
 	React.ElementRef<typeof DropdownMenuPrimitive.Content>,
@@ -106,12 +104,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
 			<DropdownMenuPrimitive.ItemIndicator>
 				<span className="h-4 w-4">
 					<svg viewBox="0 0 8 8">
-						<path
-							d="M1,4 L3,6 L7,2"
-							stroke="black"
-							strokeWidth="1"
-							fill="none"
-						/>
+						<path d="M1,4 L3,6 L7,2" stroke="black" strokeWidth="1" fill="none" />
 					</svg>
 				</span>
 			</DropdownMenuPrimitive.ItemIndicator>
@@ -119,8 +112,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
 		{children}
 	</DropdownMenuPrimitive.CheckboxItem>
 ))
-DropdownMenuCheckboxItem.displayName =
-	DropdownMenuPrimitive.CheckboxItem.displayName
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName
 
 const DropdownMenuRadioItem = React.forwardRef<
 	React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
@@ -152,11 +144,7 @@ const DropdownMenuLabel = React.forwardRef<
 >(({ className, inset, ...props }, ref) => (
 	<DropdownMenuPrimitive.Label
 		ref={ref}
-		className={cn(
-			'px-2 py-1.5 text-sm font-semibold',
-			inset && 'pl-8',
-			className,
-		)}
+		className={cn('px-2 py-1.5 text-sm font-semibold', inset && 'pl-8', className)}
 		{...props}
 	/>
 ))
@@ -174,16 +162,8 @@ const DropdownMenuSeparator = React.forwardRef<
 ))
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
 
-const DropdownMenuShortcut = ({
-	className,
-	...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
-	return (
-		<span
-			className={cn('ml-auto text-xs tracking-widest opacity-60', className)}
-			{...props}
-		/>
-	)
+const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+	return <span className={cn('ml-auto text-xs tracking-widest opacity-60', className)} {...props} />
 }
 DropdownMenuShortcut.displayName = 'DropdownMenuShortcut'
 

--- a/app/components/ui/icon.tsx
+++ b/app/components/ui/icon.tsx
@@ -46,19 +46,14 @@ export function Icon({
 }) {
 	if (children) {
 		return (
-			<span
-				className={`inline-flex items-center ${childrenSizeClassName[size]}`}
-			>
+			<span className={`inline-flex items-center ${childrenSizeClassName[size]}`}>
 				<Icon name={name} size={size} className={className} {...props} />
 				{children}
 			</span>
 		)
 	}
 	return (
-		<svg
-			{...props}
-			className={cn(sizeClassName[size], 'inline self-center', className)}
-		>
+		<svg {...props} className={cn(sizeClassName[size], 'inline self-center', className)}>
 			<use href={`${href}#${name}`} />
 		</svg>
 	)

--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -2,8 +2,7 @@ import * as React from 'react'
 
 import { cn } from '#app/utils/misc.tsx'
 
-export interface InputProps
-	extends React.InputHTMLAttributes<HTMLInputElement> {}
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
 	({ className, type, ...props }, ref) => {

--- a/app/components/ui/label.tsx
+++ b/app/components/ui/label.tsx
@@ -10,14 +10,9 @@ const labelVariants = cva(
 
 const Label = React.forwardRef<
 	React.ElementRef<typeof LabelPrimitive.Root>,
-	React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-		VariantProps<typeof labelVariants>
+	React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
 >(({ className, ...props }, ref) => (
-	<LabelPrimitive.Root
-		ref={ref}
-		className={cn(labelVariants(), className)}
-		{...props}
-	/>
+	<LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
 ))
 Label.displayName = LabelPrimitive.Root.displayName
 

--- a/app/components/ui/status-button.tsx
+++ b/app/components/ui/status-button.tsx
@@ -3,12 +3,7 @@ import { useSpinDelay } from 'spin-delay'
 import { cn } from '#app/utils/misc.tsx'
 import { Button, type ButtonProps } from './button.tsx'
 import { Icon } from './icon.tsx'
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger,
-} from './tooltip.tsx'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip.tsx'
 
 export const StatusButton = React.forwardRef<
 	HTMLButtonElement,
@@ -43,11 +38,7 @@ export const StatusButton = React.forwardRef<
 	}[status]
 
 	return (
-		<Button
-			ref={ref}
-			className={cn('flex justify-center gap-4', className)}
-			{...props}
-		>
+		<Button ref={ref} className={cn('flex justify-center gap-4', className)} {...props}>
 			<div>{children}</div>
 			{message ? (
 				<TooltipProvider>

--- a/app/components/ui/textarea.tsx
+++ b/app/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from 'react'
 
 import { cn } from '#app/utils/misc.tsx'
 
-export interface TextareaProps
-	extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 	({ className, ...props }, ref) => {

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -23,22 +23,14 @@ if (ENV.MODE === 'production' && ENV.SENTRY_DSN) {
 type DocRequestArgs = Parameters<HandleDocumentRequestFunction>
 
 export default async function handleRequest(...args: DocRequestArgs) {
-	const [
-		request,
-		responseStatusCode,
-		responseHeaders,
-		remixContext,
-		loadContext,
-	] = args
+	const [request, responseStatusCode, responseHeaders, remixContext, loadContext] = args
 	const { currentInstance, primaryInstance } = await getInstanceInfo()
 	responseHeaders.set('fly-region', process.env.FLY_REGION ?? 'unknown')
 	responseHeaders.set('fly-app', process.env.FLY_APP_NAME ?? 'unknown')
 	responseHeaders.set('fly-primary-instance', primaryInstance)
 	responseHeaders.set('fly-instance', currentInstance)
 
-	const callbackName = isbot(request.headers.get('user-agent'))
-		? 'onAllReady'
-		: 'onShellReady'
+	const callbackName = isbot(request.headers.get('user-agent')) ? 'onAllReady' : 'onShellReady'
 
 	const nonce = String(loadContext.cspNonce) ?? undefined
 	return new Promise(async (resolve, reject) => {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -250,9 +250,7 @@ function App() {
 								<div className="font-light">epic</div>
 								<div className="font-bold">notes</div>
 							</Link>
-							<div className="ml-auto hidden max-w-sm flex-1 sm:block">
-								{searchBar}
-							</div>
+							<div className="ml-auto hidden max-w-sm flex-1 sm:block">{searchBar}</div>
 							<div className="flex items-center gap-10">
 								{user ? (
 									<UserDropdown />
@@ -318,9 +316,7 @@ function UserDropdown() {
 							alt={user.name ?? user.username}
 							src={getUserImgSrc(user.image?.id)}
 						/>
-						<span className="text-body-sm font-bold">
-							{user.name ?? user.username}
-						</span>
+						<span className="text-body-sm font-bold">{user.name ?? user.username}</span>
 					</Link>
 				</Button>
 			</DropdownMenuTrigger>
@@ -400,8 +396,7 @@ function ThemeSwitch({ userPreference }: { userPreference?: Theme | null }) {
 
 	const optimisticMode = useOptimisticThemeMode()
 	const mode = optimisticMode ?? userPreference ?? 'system'
-	const nextMode =
-		mode === 'system' ? 'light' : mode === 'light' ? 'dark' : 'system'
+	const nextMode = mode === 'system' ? 'light' : mode === 'light' ? 'dark' : 'system'
 	const modeLabel = {
 		light: (
 			<Icon name="sun">
@@ -424,10 +419,7 @@ function ThemeSwitch({ userPreference }: { userPreference?: Theme | null }) {
 		<fetcher.Form method="POST" {...form.props}>
 			<input type="hidden" name="theme" value={nextMode} />
 			<div className="flex gap-2">
-				<button
-					type="submit"
-					className="flex h-8 w-8 cursor-pointer items-center justify-center"
-				>
+				<button type="submit" className="flex h-8 w-8 cursor-pointer items-center justify-center">
 					{modeLabel[mode]}
 				</button>
 			</div>

--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -28,9 +28,7 @@ export function ErrorBoundary() {
 					<div className="flex flex-col gap-6">
 						<div className="flex flex-col gap-3">
 							<h1>We can't find this page:</h1>
-							<pre className="whitespace-pre-wrap break-all text-body-lg">
-								{location.pathname}
-							</pre>
+							<pre className="whitespace-pre-wrap break-all text-body-lg">{location.pathname}</pre>
 						</div>
 						<Link to="/" className="text-body-md underline">
 							<Icon name="arrow-left">Back to home</Icon>

--- a/app/routes/_auth+/auth.$provider.callback.test.ts
+++ b/app/routes/_auth+/auth.$provider.callback.test.ts
@@ -25,9 +25,7 @@ afterEach(async () => {
 
 test('a new user goes to onboarding', async () => {
 	const request = await setupRequest()
-	const response = await loader({ request, params: PARAMS, context: {} }).catch(
-		e => e,
-	)
+	const response = await loader({ request, params: PARAMS, context: {} }).catch(e => e)
 	expect(response).toHaveRedirect('/onboarding/github')
 })
 
@@ -39,9 +37,7 @@ test('when auth fails, send the user to login with a toast', async () => {
 		}),
 	)
 	const request = await setupRequest()
-	const response = await loader({ request, params: PARAMS, context: {} }).catch(
-		e => e,
-	)
+	const response = await loader({ request, params: PARAMS, context: {} }).catch(e => e)
 	invariant(response instanceof Response, 'response should be a Response')
 	expect(response).toHaveRedirect('/login')
 	await expect(response).toSendToast(
@@ -76,10 +72,7 @@ test('when a user is logged in, it creates the connection', async () => {
 			providerId: githubUser.profile.id.toString(),
 		},
 	})
-	expect(
-		connection,
-		'the connection was not created in the database',
-	).toBeTruthy()
+	expect(connection, 'the connection was not created in the database').toBeTruthy()
 })
 
 test(`when a user is logged in and has already connected, it doesn't do anything and just redirects the user back to the connections page`, async () => {
@@ -129,10 +122,7 @@ test('when a user exists with the same email, create connection and make session
 			providerId: githubUser.profile.id.toString(),
 		},
 	})
-	expect(
-		connection,
-		'the connection was not created in the database',
-	).toBeTruthy()
+	expect(connection, 'the connection was not created in the database').toBeTruthy()
 
 	await expect(response).toHaveSessionForUser(userId)
 })
@@ -160,9 +150,7 @@ test('gives an error if the account is already connected to another user', async
 	await expect(response).toSendToast(
 		expect.objectContaining({
 			title: 'Already Connected',
-			description: expect.stringContaining(
-				'already connected to another account',
-			),
+			description: expect.stringContaining('already connected to another account'),
 		}),
 	)
 })
@@ -223,8 +211,7 @@ async function setupRequest({
 	connectionSession.set('oauth2:state', state)
 	const authSession = await authSessionStorage.getSession()
 	if (sessionId) authSession.set(sessionKey, sessionId)
-	const setSessionCookieHeader =
-		await authSessionStorage.commitSession(authSession)
+	const setSessionCookieHeader = await authSessionStorage.commitSession(authSession)
 	const setConnectionSessionCookieHeader =
 		await connectionSessionStorage.commitSession(connectionSession)
 	const request = new Request(url.toString(), {

--- a/app/routes/_auth+/auth.$provider.callback.ts
+++ b/app/routes/_auth+/auth.$provider.callback.ts
@@ -1,9 +1,5 @@
 import { redirect, type DataFunctionArgs } from '@remix-run/node'
-import {
-	authenticator,
-	getSessionExpirationDate,
-	getUserId,
-} from '#app/utils/auth.server.ts'
+import { authenticator, getSessionExpirationDate, getUserId } from '#app/utils/auth.server.ts'
 import { ProviderNameSchema, providerLabels } from '#app/utils/connections.tsx'
 import { prisma } from '#app/utils/db.server.ts'
 import { combineHeaders } from '#app/utils/misc.tsx'
@@ -11,10 +7,7 @@ import {
 	destroyRedirectToHeader,
 	getRedirectCookieValue,
 } from '#app/utils/redirect-cookie.server.ts'
-import {
-	createToastHeaders,
-	redirectWithToast,
-} from '#app/utils/toast.server.ts'
+import { createToastHeaders, redirectWithToast } from '#app/utils/toast.server.ts'
 import { verifySessionStorage } from '#app/utils/verification.server.ts'
 import { handleNewSession } from './login.tsx'
 import {
@@ -157,11 +150,7 @@ export async function loader({ request, params }: DataFunctionArgs) {
 }
 
 async function makeSession(
-	{
-		request,
-		userId,
-		redirectTo,
-	}: { request: Request; userId: string; redirectTo?: string | null },
+	{ request, userId, redirectTo }: { request: Request; userId: string; redirectTo?: string | null },
 	responseInit?: ResponseInit,
 ) {
 	redirectTo ??= '/'

--- a/app/routes/_auth+/auth.$provider.ts
+++ b/app/routes/_auth+/auth.$provider.ts
@@ -20,9 +20,7 @@ export async function action({ request, params }: DataFunctionArgs) {
 			const formData = await request.formData()
 			const rawRedirectTo = formData.get('redirectTo')
 			const redirectTo =
-				typeof rawRedirectTo === 'string'
-					? rawRedirectTo
-					: getReferrerRoute(request)
+				typeof rawRedirectTo === 'string' ? rawRedirectTo : getReferrerRoute(request)
 			const redirectToCookie = getRedirectCookieHeader(redirectTo)
 			if (redirectToCookie) {
 				error.headers.append('set-cookie', redirectToCookie)

--- a/app/routes/_auth+/forgot-password.tsx
+++ b/app/routes/_auth+/forgot-password.tsx
@@ -1,12 +1,7 @@
 import { conform, useForm } from '@conform-to/react'
 import { getFieldsetConstraint, parse } from '@conform-to/zod'
 import * as E from '@react-email/components'
-import {
-	json,
-	redirect,
-	type DataFunctionArgs,
-	type MetaFunction,
-} from '@remix-run/node'
+import { json, redirect, type DataFunctionArgs, type MetaFunction } from '@remix-run/node'
 import { Link, useFetcher } from '@remix-run/react'
 import { AuthenticityTokenInput } from 'remix-utils/csrf/react'
 import { HoneypotInputs } from 'remix-utils/honeypot/react'
@@ -33,10 +28,7 @@ export async function action({ request }: DataFunctionArgs) {
 		schema: ForgotPasswordSchema.superRefine(async (data, ctx) => {
 			const user = await prisma.user.findFirst({
 				where: {
-					OR: [
-						{ email: data.usernameOrEmail },
-						{ username: data.usernameOrEmail },
-					],
+					OR: [{ email: data.usernameOrEmail }, { username: data.usernameOrEmail }],
 				},
 				select: { id: true },
 			})
@@ -74,9 +66,7 @@ export async function action({ request }: DataFunctionArgs) {
 	const response = await sendEmail({
 		to: user.email,
 		subject: `Epic Notes Password Reset`,
-		react: (
-			<ForgotPasswordEmail onboardingUrl={verifyUrl.toString()} otp={otp} />
-		),
+		react: <ForgotPasswordEmail onboardingUrl={verifyUrl.toString()} otp={otp} />,
 	})
 
 	if (response.status === 'success') {
@@ -87,13 +77,7 @@ export async function action({ request }: DataFunctionArgs) {
 	}
 }
 
-function ForgotPasswordEmail({
-	onboardingUrl,
-	otp,
-}: {
-	onboardingUrl: string
-	otp: string
-}) {
+function ForgotPasswordEmail({ onboardingUrl, otp }: { onboardingUrl: string; otp: string }) {
 	return (
 		<E.Html lang="en" dir="ltr">
 			<E.Container>
@@ -174,10 +158,7 @@ export default function ForgotPasswordRoute() {
 							</StatusButton>
 						</div>
 					</forgotPassword.Form>
-					<Link
-						to="/login"
-						className="mt-11 text-center text-body-sm font-bold"
-					>
+					<Link to="/login" className="mt-11 text-center text-body-sm font-bold">
 						Back to Login
 					</Link>
 				</div>

--- a/app/routes/_auth+/login.tsx
+++ b/app/routes/_auth+/login.tsx
@@ -1,11 +1,6 @@
 import { conform, useForm } from '@conform-to/react'
 import { getFieldsetConstraint, parse } from '@conform-to/zod'
-import {
-	json,
-	redirect,
-	type DataFunctionArgs,
-	type MetaFunction,
-} from '@remix-run/node'
+import { json, redirect, type DataFunctionArgs, type MetaFunction } from '@remix-run/node'
 import { Form, Link, useActionData, useSearchParams } from '@remix-run/react'
 import { AuthenticityTokenInput } from 'remix-utils/csrf/react'
 import { HoneypotInputs } from 'remix-utils/honeypot/react'
@@ -16,24 +11,12 @@ import { CheckboxField, ErrorList, Field } from '#app/components/forms.tsx'
 import { Spacer } from '#app/components/spacer.tsx'
 import { StatusButton } from '#app/components/ui/status-button.tsx'
 import { twoFAVerificationType } from '#app/routes/settings+/profile.two-factor.tsx'
-import {
-	getUserId,
-	login,
-	requireAnonymous,
-	sessionKey,
-} from '#app/utils/auth.server.ts'
-import {
-	ProviderConnectionForm,
-	providerNames,
-} from '#app/utils/connections.tsx'
+import { getUserId, login, requireAnonymous, sessionKey } from '#app/utils/auth.server.ts'
+import { ProviderConnectionForm, providerNames } from '#app/utils/connections.tsx'
 import { validateCSRF } from '#app/utils/csrf.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { checkHoneypot } from '#app/utils/honeypot.server.ts'
-import {
-	combineResponseInits,
-	invariant,
-	useIsPending,
-} from '#app/utils/misc.tsx'
+import { combineResponseInits, invariant, useIsPending } from '#app/utils/misc.tsx'
 import { authSessionStorage } from '#app/utils/session.server.ts'
 import { redirectWithToast } from '#app/utils/toast.server.ts'
 import { PasswordSchema, UsernameSchema } from '#app/utils/user-validation.ts'
@@ -81,17 +64,14 @@ export async function handleNewSession(
 			combineResponseInits(
 				{
 					headers: {
-						'set-cookie':
-							await verifySessionStorage.commitSession(verifySession),
+						'set-cookie': await verifySessionStorage.commitSession(verifySession),
 					},
 				},
 				responseInit,
 			),
 		)
 	} else {
-		const authSession = await authSessionStorage.getSession(
-			request.headers.get('cookie'),
-		)
+		const authSession = await authSessionStorage.getSession(request.headers.get('cookie'))
 		authSession.set(sessionKey, session.id)
 
 		return redirect(
@@ -110,17 +90,10 @@ export async function handleNewSession(
 	}
 }
 
-export async function handleVerification({
-	request,
-	submission,
-}: VerifyFunctionArgs) {
+export async function handleVerification({ request, submission }: VerifyFunctionArgs) {
 	invariant(submission.value, 'Submission should have a value by this point')
-	const authSession = await authSessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
-	const verifySession = await verifySessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
+	const authSession = await authSessionStorage.getSession(request.headers.get('cookie'))
+	const verifySession = await verifySessionStorage.getSession(request.headers.get('cookie'))
 
 	const remember = verifySession.get(rememberKey)
 	const { redirectTo } = submission.value
@@ -149,27 +122,17 @@ export async function handleVerification({
 			}),
 		)
 	} else {
-		headers.append(
-			'set-cookie',
-			await authSessionStorage.commitSession(authSession),
-		)
+		headers.append('set-cookie', await authSessionStorage.commitSession(authSession))
 	}
 
-	headers.append(
-		'set-cookie',
-		await verifySessionStorage.destroySession(verifySession),
-	)
+	headers.append('set-cookie', await verifySessionStorage.destroySession(verifySession))
 
 	return redirect(safeRedirect(redirectTo), { headers })
 }
 
 export async function shouldRequestTwoFA(request: Request) {
-	const authSession = await authSessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
-	const verifySession = await verifySessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
+	const authSession = await authSessionStorage.getSession(request.headers.get('cookie'))
+	const verifySession = await verifySessionStorage.getSession(request.headers.get('cookie'))
 	if (verifySession.has(unverifiedSessionIdKey)) return true
 	const userId = await getUserId(request)
 	if (!userId) return false
@@ -263,9 +226,7 @@ export default function LoginPage() {
 			<div className="mx-auto w-full max-w-md">
 				<div className="flex flex-col gap-3 text-center">
 					<h1 className="text-h1">Welcome back!</h1>
-					<p className="text-body-md text-muted-foreground">
-						Please enter your details.
-					</p>
+					<p className="text-body-md text-muted-foreground">Please enter your details.</p>
 				</div>
 				<Spacer size="xs" />
 
@@ -304,18 +265,13 @@ export default function LoginPage() {
 									errors={fields.remember.errors}
 								/>
 								<div>
-									<Link
-										to="/forgot-password"
-										className="text-body-xs font-semibold"
-									>
+									<Link to="/forgot-password" className="text-body-xs font-semibold">
 										Forgot password?
 									</Link>
 								</div>
 							</div>
 
-							<input
-								{...conform.input(fields.redirectTo, { type: 'hidden' })}
-							/>
+							<input {...conform.input(fields.redirectTo, { type: 'hidden' })} />
 							<ErrorList errors={form.errors} id={form.errorId} />
 
 							<div className="flex items-center justify-between gap-6 pt-3">
@@ -342,13 +298,7 @@ export default function LoginPage() {
 						</ul>
 						<div className="flex items-center justify-center gap-2 pt-6">
 							<span className="text-muted-foreground">New here?</span>
-							<Link
-								to={
-									redirectTo
-										? `/signup?${encodeURIComponent(redirectTo)}`
-										: '/signup'
-								}
-							>
+							<Link to={redirectTo ? `/signup?${encodeURIComponent(redirectTo)}` : '/signup'}>
 								Create an account
 							</Link>
 						</div>

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -1,17 +1,7 @@
 import { conform, useForm } from '@conform-to/react'
 import { getFieldsetConstraint, parse } from '@conform-to/zod'
-import {
-	json,
-	redirect,
-	type DataFunctionArgs,
-	type MetaFunction,
-} from '@remix-run/node'
-import {
-	Form,
-	useActionData,
-	useLoaderData,
-	useSearchParams,
-} from '@remix-run/react'
+import { json, redirect, type DataFunctionArgs, type MetaFunction } from '@remix-run/node'
+import { Form, useActionData, useLoaderData, useSearchParams } from '@remix-run/react'
 import { AuthenticityTokenInput } from 'remix-utils/csrf/react'
 import { HoneypotInputs } from 'remix-utils/honeypot/react'
 import { safeRedirect } from 'remix-utils/safe-redirect'
@@ -41,8 +31,7 @@ const SignupFormSchema = z
 		username: UsernameSchema,
 		name: NameSchema,
 		agreeToTermsOfServiceAndPrivacyPolicy: z.boolean({
-			required_error:
-				'You must agree to the terms of service and privacy policy',
+			required_error: 'You must agree to the terms of service and privacy policy',
 		}),
 		remember: z.boolean().optional(),
 		redirectTo: z.string().optional(),
@@ -51,9 +40,7 @@ const SignupFormSchema = z
 
 async function requireOnboardingEmail(request: Request) {
 	await requireAnonymous(request)
-	const verifySession = await verifySessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
+	const verifySession = await verifySessionStorage.getSession(request.headers.get('cookie'))
 	const email = verifySession.get(onboardingEmailSessionKey)
 	if (typeof email !== 'string' || !email) {
 		throw redirect('/signup')
@@ -103,9 +90,7 @@ export async function action({ request }: DataFunctionArgs) {
 
 	const { session, remember, redirectTo } = submission.value
 
-	const authSession = await authSessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
+	const authSession = await authSessionStorage.getSession(request.headers.get('cookie'))
 	authSession.set(sessionKey, session.id)
 	const verifySession = await verifySessionStorage.getSession()
 	const headers = new Headers()
@@ -115,10 +100,7 @@ export async function action({ request }: DataFunctionArgs) {
 			expires: remember ? session.expirationDate : undefined,
 		}),
 	)
-	headers.append(
-		'set-cookie',
-		await verifySessionStorage.destroySession(verifySession),
-	)
+	headers.append('set-cookie', await verifySessionStorage.destroySession(verifySession))
 
 	return redirectWithConfetti(safeRedirect(redirectTo), { headers })
 }
@@ -161,16 +143,10 @@ export default function SignupRoute() {
 			<div className="mx-auto w-full max-w-lg">
 				<div className="flex flex-col gap-3 text-center">
 					<h1 className="text-h1">Welcome aboard {data.email}!</h1>
-					<p className="text-body-md text-muted-foreground">
-						Please enter your details.
-					</p>
+					<p className="text-body-md text-muted-foreground">Please enter your details.</p>
 				</div>
 				<Spacer size="xs" />
-				<Form
-					method="POST"
-					className="mx-auto min-w-[368px] max-w-sm"
-					{...form.props}
-				>
+				<Form method="POST" className="mx-auto min-w-[368px] max-w-sm" {...form.props}>
 					<AuthenticityTokenInput />
 					<HoneypotInputs />
 					<Field
@@ -214,13 +190,11 @@ export default function SignupRoute() {
 					<CheckboxField
 						labelProps={{
 							htmlFor: fields.agreeToTermsOfServiceAndPrivacyPolicy.id,
-							children:
-								'Do you agree to our Terms of Service and Privacy Policy?',
+							children: 'Do you agree to our Terms of Service and Privacy Policy?',
 						}}
-						buttonProps={conform.input(
-							fields.agreeToTermsOfServiceAndPrivacyPolicy,
-							{ type: 'checkbox' },
-						)}
+						buttonProps={conform.input(fields.agreeToTermsOfServiceAndPrivacyPolicy, {
+							type: 'checkbox',
+						})}
 						errors={fields.agreeToTermsOfServiceAndPrivacyPolicy.errors}
 					/>
 					<CheckboxField

--- a/app/routes/_auth+/onboarding_.$provider.tsx
+++ b/app/routes/_auth+/onboarding_.$provider.tsx
@@ -1,18 +1,7 @@
 import { conform, useForm } from '@conform-to/react'
 import { getFieldsetConstraint, parse } from '@conform-to/zod'
-import {
-	json,
-	redirect,
-	type DataFunctionArgs,
-	type MetaFunction,
-} from '@remix-run/node'
-import {
-	Form,
-	useActionData,
-	useLoaderData,
-	useSearchParams,
-	type Params,
-} from '@remix-run/react'
+import { json, redirect, type DataFunctionArgs, type MetaFunction } from '@remix-run/node'
+import { Form, useActionData, useLoaderData, useSearchParams, type Params } from '@remix-run/react'
 import { safeRedirect } from 'remix-utils/safe-redirect'
 import { z } from 'zod'
 import { CheckboxField, ErrorList, Field } from '#app/components/forms.tsx'
@@ -48,17 +37,9 @@ const SignupFormSchema = z.object({
 	redirectTo: z.string().optional(),
 })
 
-async function requireData({
-	request,
-	params,
-}: {
-	request: Request
-	params: Params
-}) {
+async function requireData({ request, params }: { request: Request; params: Params }) {
 	await requireAnonymous(request)
-	const verifySession = await verifySessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
+	const verifySession = await verifySessionStorage.getSession(request.headers.get('cookie'))
 	const email = verifySession.get(onboardingEmailSessionKey)
 	const providerId = verifySession.get(providerIdKey)
 	const result = z
@@ -78,12 +59,8 @@ async function requireData({
 
 export async function loader({ request, params }: DataFunctionArgs) {
 	const { email } = await requireData({ request, params })
-	const authSession = await authSessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
-	const verifySession = await verifySessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
+	const authSession = await authSessionStorage.getSession(request.headers.get('cookie'))
+	const verifySession = await verifySessionStorage.getSession(request.headers.get('cookie'))
 	const prefilledProfile = verifySession.get(prefilledProfileKey)
 
 	const formError = authSession.get(authenticator.sessionErrorKey)
@@ -107,9 +84,7 @@ export async function action({ request, params }: DataFunctionArgs) {
 		params,
 	})
 	const formData = await request.formData()
-	const verifySession = await verifySessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
+	const verifySession = await verifySessionStorage.getSession(request.headers.get('cookie'))
 
 	const submission = await parse(formData, {
 		schema: SignupFormSchema.superRefine(async (data, ctx) => {
@@ -146,9 +121,7 @@ export async function action({ request, params }: DataFunctionArgs) {
 
 	const { session, remember, redirectTo } = submission.value
 
-	const authSession = await authSessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
+	const authSession = await authSessionStorage.getSession(request.headers.get('cookie'))
 	authSession.set(sessionKey, session.id)
 	const headers = new Headers()
 	headers.append(
@@ -157,10 +130,7 @@ export async function action({ request, params }: DataFunctionArgs) {
 			expires: remember ? session.expirationDate : undefined,
 		}),
 	)
-	headers.append(
-		'set-cookie',
-		await verifySessionStorage.destroySession(verifySession),
-	)
+	headers.append('set-cookie', await verifySessionStorage.destroySession(verifySession))
 
 	return redirectWithConfetti(safeRedirect(redirectTo), { headers })
 }
@@ -202,16 +172,10 @@ export default function SignupRoute() {
 			<div className="mx-auto w-full max-w-lg">
 				<div className="flex flex-col gap-3 text-center">
 					<h1 className="text-h1">Welcome aboard {data.email}!</h1>
-					<p className="text-body-md text-muted-foreground">
-						Please enter your details.
-					</p>
+					<p className="text-body-md text-muted-foreground">Please enter your details.</p>
 				</div>
 				<Spacer size="xs" />
-				<Form
-					method="POST"
-					className="mx-auto min-w-[368px] max-w-sm"
-					{...form.props}
-				>
+				<Form method="POST" className="mx-auto min-w-[368px] max-w-sm" {...form.props}>
 					{fields.imageUrl.defaultValue ? (
 						<div className="mb-4 flex flex-col items-center justify-center gap-4">
 							<img
@@ -219,9 +183,7 @@ export default function SignupRoute() {
 								alt="Profile"
 								className="h-24 w-24 rounded-full"
 							/>
-							<p className="text-body-sm text-muted-foreground">
-								You can change your photo later
-							</p>
+							<p className="text-body-sm text-muted-foreground">You can change your photo later</p>
 							<input {...conform.input(fields.imageUrl, { type: 'hidden' })} />
 						</div>
 					) : null}
@@ -246,13 +208,11 @@ export default function SignupRoute() {
 					<CheckboxField
 						labelProps={{
 							htmlFor: fields.agreeToTermsOfServiceAndPrivacyPolicy.id,
-							children:
-								'Do you agree to our Terms of Service and Privacy Policy?',
+							children: 'Do you agree to our Terms of Service and Privacy Policy?',
 						}}
-						buttonProps={conform.input(
-							fields.agreeToTermsOfServiceAndPrivacyPolicy,
-							{ type: 'checkbox' },
-						)}
+						buttonProps={conform.input(fields.agreeToTermsOfServiceAndPrivacyPolicy, {
+							type: 'checkbox',
+						})}
 						errors={fields.agreeToTermsOfServiceAndPrivacyPolicy.errors}
 					/>
 					<CheckboxField
@@ -264,9 +224,7 @@ export default function SignupRoute() {
 						errors={fields.remember.errors}
 					/>
 
-					{redirectTo ? (
-						<input type="hidden" name="redirectTo" value={redirectTo} />
-					) : null}
+					{redirectTo ? <input type="hidden" name="redirectTo" value={redirectTo} /> : null}
 
 					<ErrorList errors={form.errors} id={form.errorId} />
 

--- a/app/routes/_auth+/reset-password.tsx
+++ b/app/routes/_auth+/reset-password.tsx
@@ -1,11 +1,6 @@
 import { conform, useForm } from '@conform-to/react'
 import { getFieldsetConstraint, parse } from '@conform-to/zod'
-import {
-	json,
-	redirect,
-	type DataFunctionArgs,
-	type MetaFunction,
-} from '@remix-run/node'
+import { json, redirect, type DataFunctionArgs, type MetaFunction } from '@remix-run/node'
 import { Form, useActionData, useLoaderData } from '@remix-run/react'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
 import { ErrorList, Field } from '#app/components/forms.tsx'
@@ -46,12 +41,8 @@ const ResetPasswordSchema = PasswordAndConfirmPasswordSchema
 
 async function requireResetPasswordUsername(request: Request) {
 	await requireAnonymous(request)
-	const verifySession = await verifySessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
-	const resetPasswordUsername = verifySession.get(
-		resetPasswordUsernameSessionKey,
-	)
+	const verifySession = await verifySessionStorage.getSession(request.headers.get('cookie'))
+	const resetPasswordUsername = verifySession.get(resetPasswordUsernameSessionKey)
 	if (typeof resetPasswordUsername !== 'string' || !resetPasswordUsername) {
 		throw redirect('/login')
 	}

--- a/app/routes/_auth+/signup.tsx
+++ b/app/routes/_auth+/signup.tsx
@@ -1,12 +1,7 @@
 import { conform, useForm } from '@conform-to/react'
 import { getFieldsetConstraint, parse } from '@conform-to/zod'
 import * as E from '@react-email/components'
-import {
-	json,
-	redirect,
-	type DataFunctionArgs,
-	type MetaFunction,
-} from '@remix-run/node'
+import { json, redirect, type DataFunctionArgs, type MetaFunction } from '@remix-run/node'
 import { Form, useActionData, useSearchParams } from '@remix-run/react'
 import { AuthenticityTokenInput } from 'remix-utils/csrf/react'
 import { HoneypotInputs } from 'remix-utils/honeypot/react'
@@ -14,10 +9,7 @@ import { z } from 'zod'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
 import { ErrorList, Field } from '#app/components/forms.tsx'
 import { StatusButton } from '#app/components/ui/status-button.tsx'
-import {
-	ProviderConnectionForm,
-	providerNames,
-} from '#app/utils/connections.tsx'
+import { ProviderConnectionForm, providerNames } from '#app/utils/connections.tsx'
 import { validateCSRF } from '#app/utils/csrf.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { sendEmail } from '#app/utils/email.server.ts'
@@ -81,13 +73,7 @@ export async function action({ request }: DataFunctionArgs) {
 	}
 }
 
-export function SignupEmail({
-	onboardingUrl,
-	otp,
-}: {
-	onboardingUrl: string
-	otp: string
-}) {
+export function SignupEmail({ onboardingUrl, otp }: { onboardingUrl: string; otp: string }) {
 	return (
 		<E.Html lang="en" dir="ltr">
 			<E.Container>
@@ -133,9 +119,7 @@ export default function SignupRoute() {
 		<div className="container flex flex-col justify-center pb-32 pt-20">
 			<div className="text-center">
 				<h1 className="text-h1">Let's start your journey!</h1>
-				<p className="mt-3 text-body-md text-muted-foreground">
-					Please enter your email.
-				</p>
+				<p className="mt-3 text-body-md text-muted-foreground">Please enter your email.</p>
 			</div>
 			<div className="mx-auto mt-16 min-w-[368px] max-w-sm">
 				<Form method="POST" {...form.props}>

--- a/app/routes/_auth+/verify.tsx
+++ b/app/routes/_auth+/verify.tsx
@@ -157,10 +157,7 @@ export async function isCodeValid({
 	return true
 }
 
-async function validateRequest(
-	request: Request,
-	body: URLSearchParams | FormData,
-) {
+async function validateRequest(request: Request, body: URLSearchParams | FormData) {
 	const submission = await parse(body, {
 		schema: VerifySchema.superRefine(async (data, ctx) => {
 			const codeIsValid = await isCodeValid({
@@ -227,9 +224,7 @@ export default function VerifyRoute() {
 	const [searchParams] = useSearchParams()
 	const isPending = useIsPending()
 	const actionData = useActionData<typeof action>()
-	const parsedType = VerificationTypeSchema.safeParse(
-		searchParams.get(typeQueryParam),
-	)
+	const parsedType = VerificationTypeSchema.safeParse(searchParams.get(typeQueryParam))
 	const type = parsedType.success ? parsedType.data : null
 
 	const checkEmail = (
@@ -272,9 +267,7 @@ export default function VerifyRoute() {
 
 	return (
 		<main className="container flex flex-col justify-center pb-32 pt-20">
-			<div className="text-center">
-				{type ? headings[type] : 'Invalid Verification Type'}
-			</div>
+			<div className="text-center">{type ? headings[type] : 'Invalid Verification Type'}</div>
 
 			<Spacer size="xs" />
 
@@ -294,12 +287,8 @@ export default function VerifyRoute() {
 							inputProps={conform.input(fields[codeQueryParam])}
 							errors={fields[codeQueryParam].errors}
 						/>
-						<input
-							{...conform.input(fields[typeQueryParam], { type: 'hidden' })}
-						/>
-						<input
-							{...conform.input(fields[targetQueryParam], { type: 'hidden' })}
-						/>
+						<input {...conform.input(fields[typeQueryParam], { type: 'hidden' })} />
+						<input {...conform.input(fields[targetQueryParam], { type: 'hidden' })} />
 						<input
 							{...conform.input(fields[redirectToQueryParam], {
 								type: 'hidden',

--- a/app/routes/_marketing+/index.tsx
+++ b/app/routes/_marketing+/index.tsx
@@ -65,11 +65,7 @@ export default function Index() {
 											href={img.href}
 											className="flex h-16 w-32 justify-center p-1 grayscale transition hover:grayscale-0 focus:grayscale-0"
 										>
-											<img
-												alt={img.alt}
-												src={img.src}
-												className="object-contain"
-											/>
+											<img alt={img.alt} src={img.src} className="object-contain" />
 										</a>
 									</TooltipTrigger>
 									<TooltipContent>{img.alt}</TooltipContent>

--- a/app/routes/_seo+/robots[.]txt.ts
+++ b/app/routes/_seo+/robots[.]txt.ts
@@ -3,7 +3,5 @@ import { type DataFunctionArgs } from '@remix-run/node'
 import { getDomainUrl } from '#app/utils/misc.tsx'
 
 export function loader({ request }: DataFunctionArgs) {
-	return generateRobotsTxt([
-		{ type: 'sitemap', value: `${getDomainUrl(request)}/sitemap.xml` },
-	])
+	return generateRobotsTxt([{ type: 'sitemap', value: `${getDomainUrl(request)}/sitemap.xml` }])
 }

--- a/app/routes/admin+/cache.tsx
+++ b/app/routes/admin+/cache.tsx
@@ -1,32 +1,12 @@
 import { type SEOHandle } from '@nasa-gcn/remix-seo'
 import { json, redirect, type DataFunctionArgs } from '@remix-run/node'
-import {
-	Form,
-	Link,
-	useFetcher,
-	useLoaderData,
-	useSearchParams,
-	useSubmit,
-} from '@remix-run/react'
+import { Form, Link, useFetcher, useLoaderData, useSearchParams, useSubmit } from '@remix-run/react'
 import { Field } from '#app/components/forms.tsx'
 import { Spacer } from '#app/components/spacer.tsx'
 import { Button } from '#app/components/ui/button.tsx'
-import {
-	cache,
-	getAllCacheKeys,
-	lruCache,
-	searchCacheKeys,
-} from '#app/utils/cache.server.ts'
-import {
-	ensureInstance,
-	getAllInstances,
-	getInstanceInfo,
-} from '#app/utils/litefs.server.ts'
-import {
-	invariantResponse,
-	useDebounce,
-	useDoubleCheck,
-} from '#app/utils/misc.tsx'
+import { cache, getAllCacheKeys, lruCache, searchCacheKeys } from '#app/utils/cache.server.ts'
+import { ensureInstance, getAllInstances, getInstanceInfo } from '#app/utils/litefs.server.ts'
+import { invariantResponse, useDebounce, useDoubleCheck } from '#app/utils/misc.tsx'
 import { requireUserWithRole } from '#app/utils/permissions.ts'
 
 export const handle: SEOHandle = {
@@ -44,8 +24,7 @@ export async function loader({ request }: DataFunctionArgs) {
 	const limit = Number(searchParams.get('limit') ?? 100)
 
 	const currentInstanceInfo = await getInstanceInfo()
-	const instance =
-		searchParams.get('instance') ?? currentInstanceInfo.currentInstance
+	const instance = searchParams.get('instance') ?? currentInstanceInfo.currentInstance
 	const instances = await getAllInstances()
 	await ensureInstance(instance)
 
@@ -110,10 +89,7 @@ export default function CacheAdminRoute() {
 			>
 				<div className="flex-1">
 					<div className="flex flex-1 gap-4">
-						<button
-							type="submit"
-							className="flex h-16 items-center justify-center"
-						>
+						<button type="submit" className="flex h-16 items-center justify-center">
 							🔎
 						</button>
 						<Field
@@ -153,12 +129,8 @@ export default function CacheAdminRoute() {
 								{[
 									inst,
 									`(${region})`,
-									inst === data.currentInstanceInfo.currentInstance
-										? '(current)'
-										: '',
-									inst === data.currentInstanceInfo.primaryInstance
-										? ' (primary)'
-										: '',
+									inst === data.currentInstanceInfo.currentInstance ? '(current)' : '',
+									inst === data.currentInstanceInfo.primaryInstance ? ' (primary)' : '',
 								]
 									.filter(Boolean)
 									.join(' ')}
@@ -171,24 +143,14 @@ export default function CacheAdminRoute() {
 			<div className="flex flex-col gap-4">
 				<h2 className="text-h2">LRU Cache:</h2>
 				{data.cacheKeys.lru.map(key => (
-					<CacheKeyRow
-						key={key}
-						cacheKey={key}
-						instance={instance}
-						type="lru"
-					/>
+					<CacheKeyRow key={key} cacheKey={key} instance={instance} type="lru" />
 				))}
 			</div>
 			<Spacer size="3xs" />
 			<div className="flex flex-col gap-4">
 				<h2 className="text-h2">SQLite Cache:</h2>
 				{data.cacheKeys.sqlite.map(key => (
-					<CacheKeyRow
-						key={key}
-						cacheKey={key}
-						instance={instance}
-						type="sqlite"
-					/>
+					<CacheKeyRow key={key} cacheKey={key} instance={instance} type="sqlite" />
 				))}
 			</div>
 		</div>
@@ -214,16 +176,8 @@ function CacheKeyRow({
 				<input type="hidden" name="cacheKey" value={cacheKey} />
 				<input type="hidden" name="instance" value={instance} />
 				<input type="hidden" name="type" value={type} />
-				<Button
-					size="sm"
-					variant="secondary"
-					{...dc.getButtonProps({ type: 'submit' })}
-				>
-					{fetcher.state === 'idle'
-						? dc.doubleCheck
-							? 'You sure?'
-							: 'Delete'
-						: 'Deleting...'}
+				<Button size="sm" variant="secondary" {...dc.getButtonProps({ type: 'submit' })}>
+					{fetcher.state === 'idle' ? (dc.doubleCheck ? 'You sure?' : 'Delete') : 'Deleting...'}
 				</Button>
 			</fetcher.Form>
 			<Link reloadDocument to={valuePage}>

--- a/app/routes/admin+/cache_.lru.$cacheKey.ts
+++ b/app/routes/admin+/cache_.lru.$cacheKey.ts
@@ -10,8 +10,7 @@ export async function loader({ request, params }: DataFunctionArgs) {
 	const searchParams = new URL(request.url).searchParams
 	const currentInstanceInfo = await getInstanceInfo()
 	const allInstances = await getAllInstances()
-	const instance =
-		searchParams.get('instance') ?? currentInstanceInfo.currentInstance
+	const instance = searchParams.get('instance') ?? currentInstanceInfo.currentInstance
 	await ensureInstance(instance)
 
 	const { cacheKey } = params

--- a/app/routes/admin+/cache_.sqlite.$cacheKey.ts
+++ b/app/routes/admin+/cache_.sqlite.$cacheKey.ts
@@ -10,8 +10,7 @@ export async function loader({ request, params }: DataFunctionArgs) {
 	const searchParams = new URL(request.url).searchParams
 	const currentInstanceInfo = await getInstanceInfo()
 	const allInstances = await getAllInstances()
-	const instance =
-		searchParams.get('instance') ?? currentInstanceInfo.currentInstance
+	const instance = searchParams.get('instance') ?? currentInstanceInfo.currentInstance
 	await ensureInstance(instance)
 
 	const { cacheKey } = params

--- a/app/routes/admin+/cache_.sqlite.tsx
+++ b/app/routes/admin+/cache_.sqlite.tsx
@@ -11,8 +11,7 @@ export async function action({ request }: DataFunctionArgs) {
 		)
 	}
 	const token = process.env.INTERNAL_COMMAND_TOKEN
-	const isAuthorized =
-		request.headers.get('Authorization') === `Bearer ${token}`
+	const isAuthorized = request.headers.get('Authorization') === `Bearer ${token}`
 	if (!isAuthorized) {
 		// nah, you can't be here...
 		return redirect('https://www.youtube.com/watch?v=dQw4w9WgXcQ')

--- a/app/routes/resources+/healthcheck.tsx
+++ b/app/routes/resources+/healthcheck.tsx
@@ -3,19 +3,16 @@ import { type DataFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 
 export async function loader({ request }: DataFunctionArgs) {
-	const host =
-    request.headers.get('X-Forwarded-Host') ?? request.headers.get('host')
+	const host = request.headers.get('X-Forwarded-Host') ?? request.headers.get('host')
 
 	try {
 		// if we can connect to the database and make a simple query
 		// and make a HEAD request to ourselves, then we're good.
 		await Promise.all([
 			prisma.user.count(),
-			fetch(`${new URL(request.url).protocol}${host}`, {method: 'HEAD'}).then(
-        r => {
-          if (!r.ok) return Promise.reject(r)
-        },
-      ),
+			fetch(`${new URL(request.url).protocol}${host}`, { method: 'HEAD' }).then(r => {
+				if (!r.ok) return Promise.reject(r)
+			}),
 		])
 		return new Response('OK')
 	} catch (error: unknown) {

--- a/app/routes/settings+/profile.change-email.tsx
+++ b/app/routes/settings+/profile.change-email.tsx
@@ -31,16 +31,11 @@ export const handle: BreadcrumbHandle & SEOHandle = {
 
 const newEmailAddressSessionKey = 'new-email-address'
 
-export async function handleVerification({
-	request,
-	submission,
-}: VerifyFunctionArgs) {
+export async function handleVerification({ request, submission }: VerifyFunctionArgs) {
 	await requireRecentVerification(request)
 	invariant(submission.value, 'submission.value should be defined by now')
 
-	const verifySession = await verifySessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
+	const verifySession = await verifySessionStorage.getSession(request.headers.get('cookie'))
 	const newEmail = verifySession.get(newEmailAddressSessionKey)
 	if (!newEmail) {
 		submission.error[''] = [
@@ -150,13 +145,7 @@ export async function action({ request }: DataFunctionArgs) {
 	}
 }
 
-export function EmailChangeEmail({
-	verifyUrl,
-	otp,
-}: {
-	verifyUrl: string
-	otp: string
-}) {
+export function EmailChangeEmail({ verifyUrl, otp }: { verifyUrl: string; otp: string }) {
 	return (
 		<E.Html lang="en" dir="ltr">
 			<E.Container>
@@ -186,15 +175,13 @@ export function EmailChangeNoticeEmail({ userId }: { userId: string }) {
 				</h1>
 				<p>
 					<E.Text>
-						We're writing to let you know that your Epic Notes email has been
-						changed.
+						We're writing to let you know that your Epic Notes email has been changed.
 					</E.Text>
 				</p>
 				<p>
 					<E.Text>
-						If you changed your email address, then you can safely ignore this.
-						But if you did not change your email address, then please contact
-						support immediately.
+						If you changed your email address, then you can safely ignore this. But if you did not
+						change your email address, then please contact support immediately.
 					</E.Text>
 				</p>
 				<p>
@@ -223,9 +210,7 @@ export default function ChangeEmailIndex() {
 		<div>
 			<h1 className="text-h1">Change Email</h1>
 			<p>You will receive an email at the new email address to confirm.</p>
-			<p>
-				An email notice will also be sent to your old address {data.user.email}.
-			</p>
+			<p>An email notice will also be sent to your old address {data.user.email}.</p>
 			<div className="mx-auto mt-5 max-w-sm">
 				<Form method="POST" {...form.props}>
 					<AuthenticityTokenInput />
@@ -236,9 +221,7 @@ export default function ChangeEmailIndex() {
 					/>
 					<ErrorList id={form.errorId} errors={form.errors} />
 					<div>
-						<StatusButton
-							status={isPending ? 'pending' : actionData?.status ?? 'idle'}
-						>
+						<StatusButton status={isPending ? 'pending' : actionData?.status ?? 'idle'}>
 							Send Confirmation
 						</StatusButton>
 					</div>

--- a/app/routes/settings+/profile.connections.tsx
+++ b/app/routes/settings+/profile.connections.tsx
@@ -67,11 +67,9 @@ export async function loader({ request }: DataFunctionArgs) {
 		const r = ProviderNameSchema.safeParse(connection.providerName)
 		if (!r.success) continue
 		const providerName = r.data
-		const connectionData = await resolveConnectionData(
-			providerName,
-			connection.providerId,
-			{ timings },
-		)
+		const connectionData = await resolveConnectionData(providerName, connection.providerId, {
+			timings,
+		})
 		connections.push({
 			...connectionData,
 			providerName,
@@ -99,10 +97,7 @@ export const headers: HeadersFunction = ({ loaderHeaders }) => {
 export async function action({ request }: DataFunctionArgs) {
 	const userId = await requireUserId(request)
 	const formData = await request.formData()
-	invariantResponse(
-		formData.get('intent') === 'delete-connection',
-		'Invalid intent',
-	)
+	invariantResponse(formData.get('intent') === 'delete-connection', 'Invalid intent')
 	invariantResponse(
 		await userCanDeleteConnections(userId),
 		'You cannot delete your last connection unless you have a password.',
@@ -133,10 +128,7 @@ export default function Connections() {
 					<ul className="flex flex-col gap-4">
 						{data.connections.map(c => (
 							<li key={c.id}>
-								<Connection
-									connection={c}
-									canDelete={data.canDeleteConnections}
-								/>
+								<Connection connection={c} canDelete={data.canDeleteConnections} />
 							</li>
 						))}
 					</ul>
@@ -146,11 +138,7 @@ export default function Connections() {
 			)}
 			<div className="mt-5 flex flex-col gap-5 border-b-2 border-t-2 border-border py-3">
 				{providerNames.map(providerName => (
-					<ProviderConnectionForm
-						key={providerName}
-						type="Connect"
-						providerName={providerName}
-					/>
+					<ProviderConnectionForm key={providerName} type="Connect" providerName={providerName} />
 				))}
 			</div>
 		</div>

--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -12,11 +12,7 @@ import { StatusButton } from '#app/components/ui/status-button.tsx'
 import { requireUserId, sessionKey } from '#app/utils/auth.server.ts'
 import { validateCSRF } from '#app/utils/csrf.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
-import {
-	getUserImgSrc,
-	invariantResponse,
-	useDoubleCheck,
-} from '#app/utils/misc.tsx'
+import { getUserImgSrc, invariantResponse, useDoubleCheck } from '#app/utils/misc.tsx'
 import { authSessionStorage } from '#app/utils/session.server.ts'
 import { redirectWithToast } from '#app/utils/toast.server.ts'
 import { NameSchema, UsernameSchema } from '#app/utils/user-validation.ts'
@@ -136,9 +132,7 @@ export default function EditUserProfile() {
 			<div className="col-span-full flex flex-col gap-6">
 				<div>
 					<Link to="change-email">
-						<Icon name="envelope-closed">
-							Change email from {data.user.email}
-						</Icon>
+						<Icon name="envelope-closed">Change email from {data.user.email}</Icon>
 					</Link>
 				</div>
 				<div>
@@ -264,11 +258,7 @@ function UpdateProfile() {
 					size="wide"
 					name="intent"
 					value={profileUpdateActionIntent}
-					status={
-						fetcher.state !== 'idle'
-							? 'pending'
-							: fetcher.data?.status ?? 'idle'
-					}
+					status={fetcher.state !== 'idle' ? 'pending' : fetcher.data?.status ?? 'idle'}
 				>
 					Save changes
 				</StatusButton>
@@ -278,14 +268,9 @@ function UpdateProfile() {
 }
 
 async function signOutOfSessionsAction({ request, userId }: ProfileActionArgs) {
-	const authSession = await authSessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
+	const authSession = await authSessionStorage.getSession(request.headers.get('cookie'))
 	const sessionId = authSession.get(sessionKey)
-	invariantResponse(
-		sessionId,
-		'You must be authenticated to sign out of other sessions',
-	)
+	invariantResponse(sessionId, 'You must be authenticated to sign out of other sessions')
 	await prisma.session.deleteMany({
 		where: {
 			userId,
@@ -313,11 +298,7 @@ function SignOutOfSessions() {
 							value: signOutOfSessionsActionIntent,
 						})}
 						variant={dc.doubleCheck ? 'destructive' : 'default'}
-						status={
-							fetcher.state !== 'idle'
-								? 'pending'
-								: fetcher.data?.status ?? 'idle'
-						}
+						status={fetcher.state !== 'idle' ? 'pending' : fetcher.data?.status ?? 'idle'}
 					>
 						<Icon name="avatar">
 							{dc.doubleCheck
@@ -359,9 +340,7 @@ function DeleteData() {
 					variant={dc.doubleCheck ? 'destructive' : 'default'}
 					status={fetcher.state !== 'idle' ? 'pending' : 'idle'}
 				>
-					<Icon name="trash">
-						{dc.doubleCheck ? `Are you sure?` : `Delete all your data`}
-					</Icon>
+					<Icon name="trash">{dc.doubleCheck ? `Are you sure?` : `Delete all your data`}</Icon>
 				</StatusButton>
 			</fetcher.Form>
 		</div>

--- a/app/routes/settings+/profile.password.tsx
+++ b/app/routes/settings+/profile.password.tsx
@@ -9,11 +9,7 @@ import { ErrorList, Field } from '#app/components/forms.tsx'
 import { Button } from '#app/components/ui/button.tsx'
 import { Icon } from '#app/components/ui/icon.tsx'
 import { StatusButton } from '#app/components/ui/status-button.tsx'
-import {
-	getPasswordHash,
-	requireUserId,
-	verifyUserPassword,
-} from '#app/utils/auth.server.ts'
+import { getPasswordHash, requireUserId, verifyUserPassword } from '#app/utils/auth.server.ts'
 import { validateCSRF } from '#app/utils/csrf.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { useIsPending } from '#app/utils/misc.tsx'
@@ -65,20 +61,18 @@ export async function action({ request }: DataFunctionArgs) {
 	await validateCSRF(formData, request.headers)
 	const submission = await parse(formData, {
 		async: true,
-		schema: ChangePasswordForm.superRefine(
-			async ({ currentPassword, newPassword }, ctx) => {
-				if (currentPassword && newPassword) {
-					const user = await verifyUserPassword({ id: userId }, currentPassword)
-					if (!user) {
-						ctx.addIssue({
-							path: ['currentPassword'],
-							code: z.ZodIssueCode.custom,
-							message: 'Incorrect password.',
-						})
-					}
+		schema: ChangePasswordForm.superRefine(async ({ currentPassword, newPassword }, ctx) => {
+			if (currentPassword && newPassword) {
+				const user = await verifyUserPassword({ id: userId }, currentPassword)
+				if (!user) {
+					ctx.addIssue({
+						path: ['currentPassword'],
+						code: z.ZodIssueCode.custom,
+						message: 'Incorrect password.',
+					})
 				}
-			},
-		),
+			}
+		}),
 	})
 	// clear the payload so we don't send the password back to the client
 	submission.payload = {}
@@ -155,10 +149,7 @@ export default function ChangePasswordRoute() {
 				<Button variant="secondary" asChild>
 					<Link to="..">Cancel</Link>
 				</Button>
-				<StatusButton
-					type="submit"
-					status={isPending ? 'pending' : actionData?.status ?? 'idle'}
-				>
+				<StatusButton type="submit" status={isPending ? 'pending' : actionData?.status ?? 'idle'}>
 					Change Password
 				</StatusButton>
 			</div>

--- a/app/routes/settings+/profile.password_.create.tsx
+++ b/app/routes/settings+/profile.password_.create.tsx
@@ -105,10 +105,7 @@ export default function CreatePasswordRoute() {
 				<Button variant="secondary" asChild>
 					<Link to="..">Cancel</Link>
 				</Button>
-				<StatusButton
-					type="submit"
-					status={isPending ? 'pending' : actionData?.status ?? 'idle'}
-				>
+				<StatusButton type="submit" status={isPending ? 'pending' : actionData?.status ?? 'idle'}>
 					Create Password
 				</StatusButton>
 			</div>

--- a/app/routes/settings+/profile.photo.tsx
+++ b/app/routes/settings+/profile.photo.tsx
@@ -8,12 +8,7 @@ import {
 	unstable_parseMultipartFormData,
 	type DataFunctionArgs,
 } from '@remix-run/node'
-import {
-	Form,
-	useActionData,
-	useLoaderData,
-	useNavigation,
-} from '@remix-run/react'
+import { Form, useActionData, useLoaderData, useNavigation } from '@remix-run/react'
 import { useState } from 'react'
 import { AuthenticityTokenInput } from 'remix-utils/csrf/react'
 import { z } from 'zod'
@@ -24,12 +19,7 @@ import { StatusButton } from '#app/components/ui/status-button.tsx'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { validateCSRF } from '#app/utils/csrf.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
-import {
-	getUserImgSrc,
-	invariantResponse,
-	useDoubleCheck,
-	useIsPending,
-} from '#app/utils/misc.tsx'
+import { getUserImgSrc, invariantResponse, useDoubleCheck, useIsPending } from '#app/utils/misc.tsx'
 import { type BreadcrumbHandle } from './profile.tsx'
 
 export const handle: BreadcrumbHandle & SEOHandle = {
@@ -156,9 +146,7 @@ export default function PhotoRoute() {
 			>
 				<AuthenticityTokenInput />
 				<img
-					src={
-						newImageSrc ?? (data.user ? getUserImgSrc(data.user.image?.id) : '')
-					}
+					src={newImageSrc ?? (data.user ? getUserImgSrc(data.user.image?.id) : '')}
 					className="h-52 w-52 rounded-full object-cover"
 					alt={data.user?.name ?? data.user?.username}
 				/>
@@ -210,11 +198,7 @@ export default function PhotoRoute() {
 					>
 						Save Photo
 					</StatusButton>
-					<Button
-						type="reset"
-						variant="destructive"
-						className="peer-invalid:hidden"
-					>
+					<Button type="reset" variant="destructive" className="peer-invalid:hidden">
 						<Icon name="trash">Reset</Icon>
 					</Button>
 					{data.user.image?.id ? (
@@ -235,9 +219,7 @@ export default function PhotoRoute() {
 							}
 						>
 							<Icon name="trash">
-								{doubleCheckDeleteImage.doubleCheck
-									? 'Are you sure?'
-									: 'Delete'}
+								{doubleCheckDeleteImage.doubleCheck ? 'Are you sure?' : 'Delete'}
 							</Icon>
 						</StatusButton>
 					) : null}

--- a/app/routes/settings+/profile.tsx
+++ b/app/routes/settings+/profile.tsx
@@ -51,10 +51,7 @@ export default function EditUserProfile() {
 			<div className="container">
 				<ul className="flex gap-3">
 					<li>
-						<Link
-							className="text-muted-foreground"
-							to={`/users/${user.username}`}
-						>
+						<Link className="text-muted-foreground" to={`/users/${user.username}`}>
 							Profile
 						</Link>
 					</li>

--- a/app/routes/settings+/profile.two-factor.disable.tsx
+++ b/app/routes/settings+/profile.two-factor.disable.tsx
@@ -45,8 +45,8 @@ export default function TwoFactorDisableRoute() {
 			<disable2FAFetcher.Form method="POST">
 				<AuthenticityTokenInput />
 				<p>
-					Disabling two factor authentication is not recommended. However, if
-					you would like to do so, click here:
+					Disabling two factor authentication is not recommended. However, if you would like to do
+					so, click here:
 				</p>
 				<StatusButton
 					variant="destructive"

--- a/app/routes/settings+/profile.two-factor.index.tsx
+++ b/app/routes/settings+/profile.two-factor.index.tsx
@@ -52,9 +52,7 @@ export default function TwoFactorRoute() {
 			{data.is2FAEnabled ? (
 				<>
 					<p className="text-lg">
-						<Icon name="check">
-							You have enabled two-factor authentication.
-						</Icon>
+						<Icon name="check">You have enabled two-factor authentication.</Icon>
 					</p>
 					<Link to="disable">
 						<Icon name="lock-open-1">Disable 2FA</Icon>
@@ -63,14 +61,11 @@ export default function TwoFactorRoute() {
 			) : (
 				<>
 					<p>
-						<Icon name="lock-open-1">
-							You have not enabled two-factor authentication yet.
-						</Icon>
+						<Icon name="lock-open-1">You have not enabled two-factor authentication yet.</Icon>
 					</p>
 					<p className="text-sm">
-						Two factor authentication adds an extra layer of security to your
-						account. You will need to enter a code from an authenticator app
-						like{' '}
+						Two factor authentication adds an extra layer of security to your account. You will need
+						to enter a code from an authenticator app like{' '}
 						<a className="underline" href="https://1password.com/">
 							1Password
 						</a>{' '}

--- a/app/routes/settings+/profile.two-factor.verify.tsx
+++ b/app/routes/settings+/profile.two-factor.verify.tsx
@@ -2,12 +2,7 @@ import { conform, useForm } from '@conform-to/react'
 import { getFieldsetConstraint, parse } from '@conform-to/zod'
 import { type SEOHandle } from '@nasa-gcn/remix-seo'
 import { json, redirect, type DataFunctionArgs } from '@remix-run/node'
-import {
-	Form,
-	useActionData,
-	useLoaderData,
-	useNavigation,
-} from '@remix-run/react'
+import { Form, useActionData, useLoaderData, useNavigation } from '@remix-run/react'
 import * as QRCode from 'qrcode'
 import { AuthenticityTokenInput } from 'remix-utils/csrf/react'
 import { z } from 'zod'
@@ -155,22 +150,18 @@ export default function TwoFactorRoute() {
 				<img alt="qr code" src={data.qrCode} className="h-56 w-56" />
 				<p>Scan this QR code with your authenticator app.</p>
 				<p className="text-sm">
-					If you cannot scan the QR code, you can manually add this account to
-					your authenticator app using this code:
+					If you cannot scan the QR code, you can manually add this account to your authenticator
+					app using this code:
 				</p>
 				<div className="p-3">
-					<pre
-						className="whitespace-pre-wrap break-all text-sm"
-						aria-label="One-time Password URI"
-					>
+					<pre className="whitespace-pre-wrap break-all text-sm" aria-label="One-time Password URI">
 						{data.otpUri}
 					</pre>
 				</div>
 				<p className="text-sm">
-					Once you've added the account, enter the code from your authenticator
-					app below. Once you enable 2FA, you will need to enter a code from
-					your authenticator app every time you log in or perform important
-					actions. Do not lose access to your authenticator app, or you will
+					Once you've added the account, enter the code from your authenticator app below. Once you
+					enable 2FA, you will need to enter a code from your authenticator app every time you log
+					in or perform important actions. Do not lose access to your authenticator app, or you will
 					lose access to your account.
 				</p>
 				<div className="flex w-full max-w-xs flex-col justify-center gap-4">

--- a/app/routes/users+/$username.test.tsx
+++ b/app/routes/users+/$username.test.tsx
@@ -15,8 +15,7 @@ import { default as UsernameRoute, loader } from './$username.tsx'
 
 test('The user profile when not logged in as self', async () => {
 	const userImages = await getUserImages()
-	const userImage =
-		userImages[faker.number.int({ min: 0, max: userImages.length - 1 })]
+	const userImage = userImages[faker.number.int({ min: 0, max: userImages.length - 1 })]
 	const user = await prisma.user.create({
 		select: { id: true, username: true, name: true },
 		data: { ...createUser(), image: { create: userImage } },
@@ -39,8 +38,7 @@ test('The user profile when not logged in as self', async () => {
 
 test('The user profile when logged in as self', async () => {
 	const userImages = await getUserImages()
-	const userImage =
-		userImages[faker.number.int({ min: 0, max: userImages.length - 1 })]
+	const userImage = userImages[faker.number.int({ min: 0, max: userImages.length - 1 })]
 	const user = await prisma.user.create({
 		select: { id: true, username: true, name: true },
 		data: { ...createUser(), image: { create: userImage } },

--- a/app/routes/users+/$username.tsx
+++ b/app/routes/users+/$username.tsx
@@ -57,9 +57,7 @@ export default function ProfileRoute() {
 					<div className="flex flex-wrap items-center justify-center gap-4">
 						<h1 className="text-center text-h2">{userDisplayName}</h1>
 					</div>
-					<p className="mt-2 text-center text-muted-foreground">
-						Joined {data.userJoinedDisplay}
-					</p>
+					<p className="mt-2 text-center text-muted-foreground">Joined {data.userJoinedDisplay}</p>
 					{isLoggedInUser ? (
 						<Form action="/logout" method="POST" className="mt-3">
 							<Button type="submit" variant="link" size="pill">
@@ -112,9 +110,7 @@ export function ErrorBoundary() {
 	return (
 		<GeneralErrorBoundary
 			statusHandlers={{
-				404: ({ params }) => (
-					<p>No user with the username "{params.username}" exists</p>
-				),
+				404: ({ params }) => <p>No user with the username "{params.username}" exists</p>,
 			}}
 		/>
 	)

--- a/app/routes/users+/$username_+/__note-editor.tsx
+++ b/app/routes/users+/$username_+/__note-editor.tsx
@@ -141,13 +141,7 @@ export async function action({ request }: DataFunctionArgs) {
 		return json({ status: 'error', submission } as const, { status: 400 })
 	}
 
-	const {
-		id: noteId,
-		title,
-		content,
-		imageUpdates = [],
-		newImages = [],
-	} = submission.value
+	const { id: noteId, title, content, imageUpdates = [], newImages = [] } = submission.value
 
 	const updatedNote = await prisma.note.upsert({
 		select: { id: true, owner: { select: { username: true } } },
@@ -172,9 +166,7 @@ export async function action({ request }: DataFunctionArgs) {
 		},
 	})
 
-	return redirect(
-		`/users/${updatedNote.owner.username}/notes/${updatedNote.id}`,
-	)
+	return redirect(`/users/${updatedNote.owner.username}/notes/${updatedNote.id}`)
 }
 
 export function NoteEditor({
@@ -240,10 +232,7 @@ export function NoteEditor({
 						<Label>Images</Label>
 						<ul className="flex flex-col gap-4">
 							{imageList.map((image, index) => (
-								<li
-									key={image.key}
-									className="relative border-b-2 border-muted-foreground"
-								>
+								<li key={image.key} className="relative border-b-2 border-muted-foreground">
 									<button
 										className="absolute right-0 top-0 text-foreground-destructive"
 										{...list.remove(fields.images.name, { index })}
@@ -258,10 +247,7 @@ export function NoteEditor({
 							))}
 						</ul>
 					</div>
-					<Button
-						className="mt-3"
-						{...list.append(fields.images.name, { defaultValue: {} })}
-					>
+					<Button className="mt-3" {...list.append(fields.images.name, { defaultValue: {} })}>
 						<span aria-hidden>
 							<Icon name="plus">Image</Icon>
 						</span>{' '}
@@ -287,11 +273,7 @@ export function NoteEditor({
 	)
 }
 
-function ImageChooser({
-	config,
-}: {
-	config: FieldConfig<z.infer<typeof ImageFieldsetSchema>>
-}) {
+function ImageChooser({ config }: { config: FieldConfig<z.infer<typeof ImageFieldsetSchema>> }) {
 	const ref = useRef<HTMLFieldSetElement>(null)
 	const fields = useFieldset(ref, config)
 	const existingImage = Boolean(fields.id.defaultValue)
@@ -312,8 +294,7 @@ function ImageChooser({
 						<label
 							htmlFor={fields.file.id}
 							className={cn('group absolute h-32 w-32 rounded-lg', {
-								'bg-accent opacity-40 focus-within:opacity-100 hover:opacity-100':
-									!previewImage,
+								'bg-accent opacity-40 focus-within:opacity-100 hover:opacity-100': !previewImage,
 								'cursor-pointer focus-within:ring-4': !existingImage,
 							})}
 						>
@@ -378,10 +359,7 @@ function ImageChooser({
 						{...conform.textarea(fields.altText, { ariaAttributes: true })}
 					/>
 					<div className="min-h-[32px] px-4 pb-3 pt-1">
-						<ErrorList
-							id={fields.altText.errorId}
-							errors={fields.altText.errors}
-						/>
+						<ErrorList id={fields.altText.errorId} errors={fields.altText.errors} />
 					</div>
 				</div>
 			</div>
@@ -396,9 +374,7 @@ export function ErrorBoundary() {
 	return (
 		<GeneralErrorBoundary
 			statusHandlers={{
-				404: ({ params }) => (
-					<p>No note with the id "{params.noteId}" exists</p>
-				),
+				404: ({ params }) => <p>No note with the id "{params.noteId}" exists</p>,
 			}}
 		/>
 	)

--- a/app/routes/users+/$username_+/notes.$noteId.tsx
+++ b/app/routes/users+/$username_+/notes.$noteId.tsx
@@ -1,13 +1,7 @@
 import { useForm } from '@conform-to/react'
 import { parse } from '@conform-to/zod'
 import { json, type DataFunctionArgs } from '@remix-run/node'
-import {
-	Form,
-	Link,
-	useActionData,
-	useLoaderData,
-	type MetaFunction,
-} from '@remix-run/react'
+import { Form, Link, useActionData, useLoaderData, type MetaFunction } from '@remix-run/react'
 import { formatDistanceToNow } from 'date-fns'
 import { AuthenticityTokenInput } from 'remix-utils/csrf/react'
 import { z } from 'zod'
@@ -20,15 +14,8 @@ import { StatusButton } from '#app/components/ui/status-button.tsx'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { validateCSRF } from '#app/utils/csrf.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
-import {
-	getNoteImgSrc,
-	invariantResponse,
-	useIsPending,
-} from '#app/utils/misc.tsx'
-import {
-	requireUserWithPermission,
-	userHasPermission,
-} from '#app/utils/permissions.ts'
+import { getNoteImgSrc, invariantResponse, useIsPending } from '#app/utils/misc.tsx'
+import { requireUserWithPermission, userHasPermission } from '#app/utils/permissions.ts'
 import { redirectWithToast } from '#app/utils/toast.server.ts'
 import { useOptionalUser } from '#app/utils/user.ts'
 import { type loader as notesLoader } from './notes.tsx'
@@ -90,10 +77,7 @@ export async function action({ request }: DataFunctionArgs) {
 	invariantResponse(note, 'Not found', { status: 404 })
 
 	const isOwner = note.ownerId === userId
-	await requireUserWithPermission(
-		request,
-		isOwner ? `delete:note:own` : `delete:note:any`,
-	)
+	await requireUserWithPermission(request, isOwner ? `delete:note:own` : `delete:note:any`)
 
 	await prisma.note.delete({ where: { id: note.id } })
 
@@ -108,10 +92,7 @@ export default function NoteRoute() {
 	const data = useLoaderData<typeof loader>()
 	const user = useOptionalUser()
 	const isOwner = user?.id === data.note.ownerId
-	const canDelete = userHasPermission(
-		user,
-		isOwner ? `delete:note:own` : `delete:note:any`,
-	)
+	const canDelete = userHasPermission(user, isOwner ? `delete:note:own` : `delete:note:any`)
 	const displayBar = canDelete || isOwner
 
 	return (
@@ -131,9 +112,7 @@ export default function NoteRoute() {
 						</li>
 					))}
 				</ul>
-				<p className="whitespace-break-spaces text-sm md:text-lg">
-					{data.note.content}
-				</p>
+				<p className="whitespace-break-spaces text-sm md:text-lg">{data.note.content}</p>
 			</div>
 			{displayBar ? (
 				<div className={floatingToolbarClassName}>
@@ -144,10 +123,7 @@ export default function NoteRoute() {
 					</span>
 					<div className="grid flex-1 grid-cols-2 justify-end gap-2 min-[525px]:flex md:gap-4">
 						{canDelete ? <DeleteNote id={data.note.id} /> : null}
-						<Button
-							asChild
-							className="min-[525px]:max-md:aspect-square min-[525px]:max-md:px-0"
-						>
+						<Button asChild className="min-[525px]:max-md:aspect-square min-[525px]:max-md:px-0">
 							<Link to="edit">
 								<Icon name="pencil-1" className="scale-125 max-md:scale-150">
 									<span className="max-md:hidden">Edit</span>
@@ -195,15 +171,11 @@ export const meta: MetaFunction<
 	typeof loader,
 	{ 'routes/users+/$username_+/notes': typeof notesLoader }
 > = ({ data, params, matches }) => {
-	const notesMatch = matches.find(
-		m => m.id === 'routes/users+/$username_+/notes',
-	)
+	const notesMatch = matches.find(m => m.id === 'routes/users+/$username_+/notes')
 	const displayName = notesMatch?.data?.owner.name ?? params.username
 	const noteTitle = data?.note.title ?? 'Note'
 	const noteContentsSummary =
-		data && data.note.content.length > 100
-			? data?.note.content.slice(0, 97) + '...'
-			: 'No content'
+		data && data.note.content.length > 100 ? data?.note.content.slice(0, 97) + '...' : 'No content'
 	return [
 		{ title: `${noteTitle} | ${displayName}'s Notes | Epic Notes` },
 		{
@@ -218,9 +190,7 @@ export function ErrorBoundary() {
 		<GeneralErrorBoundary
 			statusHandlers={{
 				403: () => <p>You are not allowed to do that</p>,
-				404: ({ params }) => (
-					<p>No note with the id "{params.noteId}" exists</p>
-				),
+				404: ({ params }) => <p>No note with the id "{params.noteId}" exists</p>,
 			}}
 		/>
 	)

--- a/app/routes/users+/$username_+/notes.index.tsx
+++ b/app/routes/users+/$username_+/notes.index.tsx
@@ -13,9 +13,7 @@ export const meta: MetaFunction<
 	null,
 	{ 'routes/users+/$username_+/notes': typeof notesLoader }
 > = ({ params, matches }) => {
-	const notesMatch = matches.find(
-		m => m.id === 'routes/users+/$username_+/notes',
-	)
+	const notesMatch = matches.find(m => m.id === 'routes/users+/$username_+/notes')
 	const displayName = notesMatch?.data?.owner.name ?? params.username
 	const noteCount = notesMatch?.data?.owner.notes.length ?? 0
 	const notesText = noteCount === 1 ? 'note' : 'notes'

--- a/app/routes/users+/$username_+/notes.tsx
+++ b/app/routes/users+/$username_+/notes.tsx
@@ -90,9 +90,7 @@ export function ErrorBoundary() {
 	return (
 		<GeneralErrorBoundary
 			statusHandlers={{
-				404: ({ params }) => (
-					<p>No user with the username "{params.username}" exists</p>
-				),
+				404: ({ params }) => <p>No user with the username "{params.username}" exists</p>,
 			}}
 		/>
 	)

--- a/app/routes/users+/index.tsx
+++ b/app/routes/users+/index.tsx
@@ -69,10 +69,9 @@ export default function UsersRoute() {
 				{data.status === 'idle' ? (
 					data.users.length ? (
 						<ul
-							className={cn(
-								'flex w-full flex-wrap items-center justify-center gap-4 delay-200',
-								{ 'opacity-50': isPending },
-							)}
+							className={cn('flex w-full flex-wrap items-center justify-center gap-4 delay-200', {
+								'opacity-50': isPending,
+							})}
 						>
 							{data.users.map(user => (
 								<li key={user.id}>

--- a/app/styles/font.css
+++ b/app/styles/font.css
@@ -5,11 +5,9 @@
 	font-style: normal;
 	font-weight: 200;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-200.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-200.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-200.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-200.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* nunito-sans-200italic - latin_latin-ext */
 @font-face {
@@ -18,11 +16,9 @@
 	font-style: italic;
 	font-weight: 200;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-200italic.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-200italic.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-200italic.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-200italic.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* nunito-sans-300 - latin_latin-ext */
 @font-face {
@@ -31,11 +27,9 @@
 	font-style: normal;
 	font-weight: 300;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-300.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-300.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-300.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-300.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* nunito-sans-300italic - latin_latin-ext */
 @font-face {
@@ -44,11 +38,9 @@
 	font-style: italic;
 	font-weight: 300;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-300italic.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-300italic.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-300italic.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-300italic.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* nunito-sans-regular - latin_latin-ext */
 @font-face {
@@ -57,11 +49,9 @@
 	font-style: normal;
 	font-weight: 400;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-regular.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-regular.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-regular.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-regular.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* nunito-sans-italic - latin_latin-ext */
 @font-face {
@@ -70,11 +60,9 @@
 	font-style: italic;
 	font-weight: 400;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-italic.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-italic.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-italic.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-italic.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* nunito-sans-600 - latin_latin-ext */
 @font-face {
@@ -83,11 +71,9 @@
 	font-style: normal;
 	font-weight: 600;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-600.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-600.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-600.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-600.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* nunito-sans-600italic - latin_latin-ext */
 @font-face {
@@ -96,11 +82,9 @@
 	font-style: italic;
 	font-weight: 600;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-600italic.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-600italic.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-600italic.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-600italic.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* nunito-sans-700 - latin_latin-ext */
 @font-face {
@@ -109,11 +93,9 @@
 	font-style: normal;
 	font-weight: 700;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-700.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-700.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-700.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-700.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* nunito-sans-700italic - latin_latin-ext */
 @font-face {
@@ -122,11 +104,9 @@
 	font-style: italic;
 	font-weight: 700;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-700italic.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-700italic.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-700italic.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-700italic.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* nunito-sans-800 - latin_latin-ext */
 @font-face {
@@ -135,11 +115,9 @@
 	font-style: normal;
 	font-weight: 800;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-800.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-800.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-800.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-800.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* nunito-sans-800italic - latin_latin-ext */
 @font-face {
@@ -148,11 +126,9 @@
 	font-style: italic;
 	font-weight: 800;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-800italic.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-800italic.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-800italic.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-800italic.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* nunito-sans-900 - latin_latin-ext */
 @font-face {
@@ -161,11 +137,9 @@
 	font-style: normal;
 	font-weight: 900;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-900.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-900.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-900.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-900.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* nunito-sans-900italic - latin_latin-ext */
 @font-face {
@@ -174,11 +148,9 @@
 	font-style: italic;
 	font-weight: 900;
 	src:
-		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-900italic.woff2')
-			format('woff2'),
+		url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-900italic.woff2') format('woff2'),
 		/* Chrome 36+, Opera 23+, Firefox 39+ */
-			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-900italic.woff')
-			format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+			url('/fonts/nunito-sans/nunito-sans-v12-latin_latin-ext-900italic.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* Font metric overrides reduces CLS from font-swap.
 This is manually inserted, metric generated using CLI commands:

--- a/app/utils/cache.server.ts
+++ b/app/utils/cache.server.ts
@@ -47,10 +47,7 @@ function createDatabase(tryAgain = true): Database.Database {
 	return db
 }
 
-const lru = remember(
-	'lru-cache',
-	() => new LRUCache<string, CacheEntry<unknown>>({ max: 5000 }),
-)
+const lru = remember('lru-cache', () => new LRUCache<string, CacheEntry<unknown>>({ max: 5000 }))
 
 export const lruCache = lruCacheAdapter(lru)
 
@@ -70,9 +67,7 @@ const cacheQueryResultSchema = z.object({
 export const cache: CachifiedCache = {
 	name: 'SQLite cache',
 	get(key) {
-		const result = cacheDb
-			.prepare('SELECT value, metadata FROM cache WHERE key = ?')
-			.get(key)
+		const result = cacheDb.prepare('SELECT value, metadata FROM cache WHERE key = ?').get(key)
 		const parseResult = cacheQueryResultSchema.safeParse(result)
 		if (!parseResult.success) return null
 

--- a/app/utils/client-hints.tsx
+++ b/app/utils/client-hints.tsx
@@ -56,9 +56,7 @@ export function getHints(request?: Request) {
 		(acc, [name, hint]) => {
 			const hintName = name as ClientHintNames
 			if ('transform' in hint) {
-				acc[hintName] = hint.transform(
-					getCookieValue(cookieString, hintName) ?? hint.fallback,
-				)
+				acc[hintName] = hint.transform(getCookieValue(cookieString, hintName) ?? hint.fallback)
 			} else {
 				// @ts-expect-error - this is fine (PRs welcome though)
 				acc[hintName] = getCookieValue(cookieString, hintName) ?? hint.fallback

--- a/app/utils/confetti.server.ts
+++ b/app/utils/confetti.server.ts
@@ -6,9 +6,7 @@ const cookieName = 'en_confetti'
 
 export function getConfetti(request: Request) {
 	const cookieHeader = request.headers.get('cookie')
-	const confettiId = cookieHeader
-		? cookie.parse(cookieHeader)[cookieName]
-		: null
+	const confettiId = cookieHeader ? cookie.parse(cookieHeader)[cookieName] : null
 	return {
 		confettiId,
 		headers: confettiId ? createConfettiHeaders(null) : null,
@@ -23,9 +21,7 @@ export function getConfetti(request: Request) {
  * @param value the value for the cookie in the set-cookie header
  * @returns Headers with a set-cookie header set to the value
  */
-export function createConfettiHeaders(
-	value: string | null = String(Date.now()),
-) {
+export function createConfettiHeaders(value: string | null = String(Date.now())) {
 	return new Headers({
 		'set-cookie': cookie.serialize(cookieName, value ? value : '', {
 			path: '/',

--- a/app/utils/connections.tsx
+++ b/app/utils/connections.tsx
@@ -32,19 +32,9 @@ export function ProviderConnectionForm({
 	const formAction = `/auth/${providerName}`
 	const isPending = useIsPending({ formAction })
 	return (
-		<Form
-			className="flex items-center justify-center gap-2"
-			action={formAction}
-			method="POST"
-		>
-			{redirectTo ? (
-				<input type="hidden" name="redirectTo" value={redirectTo} />
-			) : null}
-			<StatusButton
-				type="submit"
-				className="w-full"
-				status={isPending ? 'pending' : 'idle'}
-			>
+		<Form className="flex items-center justify-center gap-2" action={formAction} method="POST">
+			{redirectTo ? <input type="hidden" name="redirectTo" value={redirectTo} /> : null}
+			<StatusButton type="submit" className="w-full" status={isPending ? 'pending' : 'idle'}>
 				<span className="inline-flex items-center gap-1.5">
 					{providerIcons[providerName]}
 					<span>

--- a/app/utils/email.server.ts
+++ b/app/utils/email.server.ts
@@ -42,9 +42,7 @@ export async function sendEmail({
 	// feel free to remove this condition once you've set up resend
 	if (!process.env.RESEND_API_KEY && !process.env.MOCKS) {
 		console.error(`RESEND_API_KEY not set and we're not in mocks mode.`)
-		console.error(
-			`To send emails, set the RESEND_API_KEY environment variable.`,
-		)
+		console.error(`To send emails, set the RESEND_API_KEY environment variable.`)
 		console.error(`Would have sent the following email:`, JSON.stringify(email))
 		return {
 			status: 'success',

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -28,10 +28,7 @@ export function init() {
 	const parsed = schema.safeParse(process.env)
 
 	if (parsed.success === false) {
-		console.error(
-			'❌ Invalid environment variables:',
-			parsed.error.flatten().fieldErrors,
-		)
+		console.error('❌ Invalid environment variables:', parsed.error.flatten().fieldErrors)
 
 		throw new Error('Invalid envirmonment variables')
 	}

--- a/app/utils/misc.error-message.test.ts
+++ b/app/utils/misc.error-message.test.ts
@@ -16,9 +16,6 @@ test('String returns itself', () => {
 test('undefined falls back to Unknown', () => {
 	consoleError.mockImplementation(() => {})
 	expect(getErrorMessage(undefined)).toBe('Unknown Error')
-	expect(consoleError).toHaveBeenCalledWith(
-		'Unable to get error message for error',
-		undefined,
-	)
+	expect(consoleError).toHaveBeenCalledWith('Unable to get error message for error', undefined)
 	expect(consoleError).toHaveBeenCalledTimes(1)
 })

--- a/app/utils/misc.tsx
+++ b/app/utils/misc.tsx
@@ -33,9 +33,7 @@ function formatColors() {
 		if (typeof color === 'string') {
 			colors.push(key)
 		} else {
-			const colorGroup = Object.keys(color).map(subKey =>
-				subKey === 'DEFAULT' ? '' : subKey,
-			)
+			const colorGroup = Object.keys(color).map(subKey => (subKey === 'DEFAULT' ? '' : subKey))
 			colors.push({ [key]: colorGroup })
 		}
 	}
@@ -78,9 +76,7 @@ export function getReferrerRoute(request: Request) {
 	// spelling errors and whatever makes this annoyingly inconsistent
 	// in my own testing, `referer` returned the right value, but 🤷‍♂️
 	const referrer =
-		request.headers.get('referer') ??
-		request.headers.get('referrer') ??
-		request.referrer
+		request.headers.get('referer') ?? request.headers.get('referrer') ?? request.referrer
 	const domain = getDomainUrl(request)
 	if (referrer?.startsWith(domain)) {
 		return referrer.slice(domain.length)
@@ -92,9 +88,7 @@ export function getReferrerRoute(request: Request) {
 /**
  * Merge multiple headers objects into one (uses set so headers are overridden)
  */
-export function mergeHeaders(
-	...headers: Array<ResponseInit['headers'] | null | undefined>
-) {
+export function mergeHeaders(...headers: Array<ResponseInit['headers'] | null | undefined>) {
 	const merged = new Headers()
 	for (const header of headers) {
 		if (!header) continue
@@ -108,9 +102,7 @@ export function mergeHeaders(
 /**
  * Combine multiple header objects into one (uses append so headers are not overridden)
  */
-export function combineHeaders(
-	...headers: Array<ResponseInit['headers'] | null | undefined>
-) {
+export function combineHeaders(...headers: Array<ResponseInit['headers'] | null | undefined>) {
 	const combined = new Headers()
 	for (const header of headers) {
 		if (!header) continue
@@ -124,9 +116,7 @@ export function combineHeaders(
 /**
  * Combine multiple response init objects into one (uses combineHeaders)
  */
-export function combineResponseInits(
-	...responseInits: Array<ResponseInit | null | undefined>
-) {
+export function combineResponseInits(...responseInits: Array<ResponseInit | null | undefined>) {
 	let combined: ResponseInit = {}
 	for (const responseInit of responseInits) {
 		combined = {
@@ -153,10 +143,7 @@ export function combineResponseInits(
  *
  * @throws {Error} if condition is falsey
  */
-export function invariant(
-	condition: any,
-	message: string | (() => string),
-): asserts condition {
+export function invariant(condition: any, message: string | (() => string)): asserts condition {
 	if (!condition) {
 		throw new Error(typeof message === 'function' ? message() : message)
 	}
@@ -212,9 +199,7 @@ export function useIsPending({
 	const contextualFormAction = useFormAction()
 	const navigation = useNavigation()
 	const isPendingState =
-		state === 'non-idle'
-			? navigation.state !== 'idle'
-			: navigation.state === state
+		state === 'non-idle' ? navigation.state !== 'idle' : navigation.state === state
 	return (
 		isPendingState &&
 		navigation.formAction === (formAction ?? contextualFormAction) &&
@@ -235,8 +220,7 @@ export function useDelayedIsPending({
 	formMethod,
 	delay = 400,
 	minDuration = 300,
-}: Parameters<typeof useIsPending>[0] &
-	Parameters<typeof useSpinDelay>[1] = {}) {
+}: Parameters<typeof useIsPending>[0] & Parameters<typeof useSpinDelay>[1] = {}) {
 	const isPending = useIsPending({ formAction, formMethod })
 	const delayedIsPending = useSpinDelay(isPending, {
 		delay,
@@ -260,26 +244,22 @@ function callAll<Args extends Array<unknown>>(
 export function useDoubleCheck() {
 	const [doubleCheck, setDoubleCheck] = useState(false)
 
-	function getButtonProps(
-		props?: React.ButtonHTMLAttributes<HTMLButtonElement>,
-	) {
-		const onBlur: React.ButtonHTMLAttributes<HTMLButtonElement>['onBlur'] =
-			() => setDoubleCheck(false)
+	function getButtonProps(props?: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+		const onBlur: React.ButtonHTMLAttributes<HTMLButtonElement>['onBlur'] = () =>
+			setDoubleCheck(false)
 
-		const onClick: React.ButtonHTMLAttributes<HTMLButtonElement>['onClick'] =
-			doubleCheck
-				? undefined
-				: e => {
-						e.preventDefault()
-						setDoubleCheck(true)
-				  }
+		const onClick: React.ButtonHTMLAttributes<HTMLButtonElement>['onClick'] = doubleCheck
+			? undefined
+			: e => {
+					e.preventDefault()
+					setDoubleCheck(true)
+			  }
 
-		const onKeyUp: React.ButtonHTMLAttributes<HTMLButtonElement>['onKeyUp'] =
-			e => {
-				if (e.key === 'Escape') {
-					setDoubleCheck(false)
-				}
+		const onKeyUp: React.ButtonHTMLAttributes<HTMLButtonElement>['onKeyUp'] = e => {
+			if (e.key === 'Escape') {
+				setDoubleCheck(false)
 			}
+		}
 
 		return {
 			...props,
@@ -319,11 +299,7 @@ export function useDebounce<
 		callbackRef.current = callback
 	})
 	return useMemo(
-		() =>
-			debounce(
-				(...args: Parameters<Callback>) => callbackRef.current(...args),
-				delay,
-			),
+		() => debounce((...args: Parameters<Callback>) => callbackRef.current(...args), delay),
 		[delay],
 	)
 }

--- a/app/utils/misc.use-double-check.test.tsx
+++ b/app/utils/misc.use-double-check.test.tsx
@@ -8,9 +8,7 @@ import { expect, test } from 'vitest'
 import { useDoubleCheck } from './misc.tsx'
 
 function TestComponent() {
-	const [defaultPrevented, setDefaultPrevented] = useState<
-		'idle' | 'no' | 'yes'
-	>('idle')
+	const [defaultPrevented, setDefaultPrevented] = useState<'idle' | 'no' | 'yes'>('idle')
 	const dc = useDoubleCheck()
 	return (
 		<div>

--- a/app/utils/permissions.ts
+++ b/app/utils/permissions.ts
@@ -3,10 +3,7 @@ import { requireUserId } from './auth.server.ts'
 import { prisma } from './db.server.ts'
 import { type useUser } from './user.ts'
 
-export async function requireUserWithPermission(
-	request: Request,
-	permission: PermissionString,
-) {
+export async function requireUserWithPermission(request: Request, permission: PermissionString) {
 	const userId = await requireUserId(request)
 	const permissionData = parsePermissionString(permission)
 	const user = await prisma.user.findFirst({
@@ -18,9 +15,7 @@ export async function requireUserWithPermission(
 					permissions: {
 						some: {
 							...permissionData,
-							access: permissionData.access
-								? { in: permissionData.access }
-								: undefined,
+							access: permissionData.access ? { in: permissionData.access } : undefined,
 						},
 					},
 				},
@@ -92,10 +87,7 @@ export function userHasPermission(
 	)
 }
 
-export function userHasRole(
-	user: Pick<ReturnType<typeof useUser>, 'roles'> | null,
-	role: string,
-) {
+export function userHasRole(user: Pick<ReturnType<typeof useUser>, 'roles'> | null, role: string) {
 	if (!user) return false
 	return user.roles.some(r => r.name === role)
 }

--- a/app/utils/providers/github.server.ts
+++ b/app/utils/providers/github.server.ts
@@ -44,10 +44,7 @@ export class GitHubProvider implements AuthProvider {
 		)
 	}
 
-	async resolveConnectionData(
-		providerId: string,
-		{ timings }: { timings?: Timings } = {},
-	) {
+	async resolveConnectionData(providerId: string, { timings }: { timings?: Timings } = {}) {
 		const result = await cachified({
 			key: `connection-data:github:${providerId}`,
 			cache,
@@ -56,10 +53,9 @@ export class GitHubProvider implements AuthProvider {
 			swr: 1000 * 60 * 60 * 24 * 7,
 			async getFreshValue(context) {
 				await new Promise(r => setTimeout(r, 3000))
-				const response = await fetch(
-					`https://api.github.com/user/${providerId}`,
-					{ headers: { Authorization: `token ${process.env.GITHUB_TOKEN}` } },
-				)
+				const response = await fetch(`https://api.github.com/user/${providerId}`, {
+					headers: { Authorization: `token ${process.env.GITHUB_TOKEN}` },
+				})
 				const rawJson = await response.json()
 				const result = GitHubUserSchema.safeParse(rawJson)
 				if (!result.success) {
@@ -89,8 +85,7 @@ export class GitHubProvider implements AuthProvider {
 		const searchParams = new URLSearchParams({ code, state })
 		throw redirect(`/auth/github/callback?${searchParams}`, {
 			headers: {
-				'set-cookie':
-					await connectionSessionStorage.commitSession(connectionSession),
+				'set-cookie': await connectionSessionStorage.commitSession(connectionSession),
 			},
 		})
 	}

--- a/app/utils/session.server.ts
+++ b/app/utils/session.server.ts
@@ -16,9 +16,7 @@ export const authSessionStorage = createCookieSessionStorage({
 const originalCommitSession = authSessionStorage.commitSession
 
 Object.defineProperty(authSessionStorage, 'commitSession', {
-	value: async function commitSession(
-		...args: Parameters<typeof originalCommitSession>
-	) {
+	value: async function commitSession(...args: Parameters<typeof originalCommitSession>) {
 		const [session, options] = args
 		if (options?.expires) {
 			session.set('expires', options.expires)
@@ -26,9 +24,7 @@ Object.defineProperty(authSessionStorage, 'commitSession', {
 		if (options?.maxAge) {
 			session.set('expires', new Date(Date.now() + options.maxAge * 1000))
 		}
-		const expires = session.has('expires')
-			? new Date(session.get('expires'))
-			: undefined
+		const expires = session.has('expires') ? new Date(session.get('expires')) : undefined
 		const setCookieHeader = await originalCommitSession(session, {
 			...options,
 			expires,

--- a/app/utils/timing.server.ts
+++ b/app/utils/timing.server.ts
@@ -2,12 +2,7 @@ import { type CreateReporter } from 'cachified'
 
 export type Timings = Record<
 	string,
-	Array<
-		{ desc?: string } & (
-			| { time: number; start?: never }
-			| { time?: never; start: number }
-		)
-	>
+	Array<{ desc?: string } & ({ time: number; start?: never } | { time?: never; start: number })>
 >
 
 export function makeTimings(type: string, desc?: string) {
@@ -97,10 +92,7 @@ export function cachifiedTimingReporter<Value>(
 	if (!timings) return
 
 	return ({ key }) => {
-		const cacheRetrievalTimer = createTimer(
-			`cache:${key}`,
-			`${key} cache retrieval`,
-		)
+		const cacheRetrievalTimer = createTimer(`cache:${key}`, `${key} cache retrieval`)
 		let getFreshValueTimer: ReturnType<typeof createTimer> | undefined
 		return event => {
 			switch (event.name) {

--- a/app/utils/toast.server.ts
+++ b/app/utils/toast.server.ts
@@ -30,11 +30,7 @@ export const toastSessionStorage = createCookieSessionStorage({
 	},
 })
 
-export async function redirectWithToast(
-	url: string,
-	toast: OptionalToast,
-	init?: ResponseInit,
-) {
+export async function redirectWithToast(url: string, toast: OptionalToast, init?: ResponseInit) {
 	return redirect(url, {
 		...init,
 		headers: combineHeaders(init?.headers, await createToastHeaders(toast)),
@@ -50,9 +46,7 @@ export async function createToastHeaders(optionalToast: OptionalToast) {
 }
 
 export async function getToast(request: Request) {
-	const session = await toastSessionStorage.getSession(
-		request.headers.get('cookie'),
-	)
+	const session = await toastSessionStorage.getSession(request.headers.get('cookie'))
 	const result = ToastSchema.safeParse(session.get(toastKey))
 	const toast = result.success ? result.data : null
 	return {

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -60,16 +60,19 @@ This page links to examples of how to implement some things with the Epic Stack.
   using [i18next](https://www.i18next.com/) and
   [remix-18next](https://github.com/sergiodxa/remix-i18next)
 - [Epic Stack + Argos](https://github.com/jsfez/epic-stack-with-argos) by
-  [@jsfez](https://github.com/jsfez): An example of the Epic Stack
-  with [Argos](https://www.argos-ci.com/) for visual testing
+  [@jsfez](https://github.com/jsfez): An example of the Epic Stack with
+  [Argos](https://www.argos-ci.com/) for visual testing
 - [Epic Stack monorepo with pnpm + turbo](https://github.com/PhilDL/epic-stack-monorepo):
-  An example of the Epic Stack in a monorepo setup, configs packages, UI package, and "client-hints" example package.
-- [Epic Stack + passkeys/webauthn](https://github.com/rperon/epic-stack-with-passkeys/) by
-  [@rperon](https://github.com/rperon): An example of the Epic Stack with passkeys
-  using [remix-auth-webauthn](https://github.com/alexanderson1993/remix-auth-webauthn) and 
-  [remix-auth](https://npm.im/remix-auth).
-- [Epic Stack with jsx-email](https://github.com/djhi/epic-stack-jsx-email):
-  An example of the Epic Stack that uses [jsx-email](https://jsx.email/) instead of [react-email](https://react.email/)
+  An example of the Epic Stack in a monorepo setup, configs packages, UI
+  package, and "client-hints" example package.
+- [Epic Stack + passkeys/webauthn](https://github.com/rperon/epic-stack-with-passkeys/)
+  by [@rperon](https://github.com/rperon): An example of the Epic Stack with
+  passkeys using
+  [remix-auth-webauthn](https://github.com/alexanderson1993/remix-auth-webauthn)
+  and [remix-auth](https://npm.im/remix-auth).
+- [Epic Stack with jsx-email](https://github.com/djhi/epic-stack-jsx-email): An
+  example of the Epic Stack that uses [jsx-email](https://jsx.email/) instead of
+  [react-email](https://react.email/)
 
 ## How to contribute
 

--- a/other/build-icons.ts
+++ b/other/build-icons.ts
@@ -28,21 +28,13 @@ if (files.length === 0) {
 async function generateIconFiles() {
 	const spriteFilepath = path.join(outputDir, 'sprite.svg')
 	const typeOutputFilepath = path.join(outputDir, 'name.d.ts')
-	const currentSprite = await fsExtra
-		.readFile(spriteFilepath, 'utf8')
-		.catch(() => '')
-	const currentTypes = await fsExtra
-		.readFile(typeOutputFilepath, 'utf8')
-		.catch(() => '')
+	const currentSprite = await fsExtra.readFile(spriteFilepath, 'utf8').catch(() => '')
+	const currentTypes = await fsExtra.readFile(typeOutputFilepath, 'utf8').catch(() => '')
 
 	const iconNames = files.map(file => iconName(file))
 
-	const spriteUpToDate = iconNames.every(name =>
-		currentSprite.includes(`id=${name}`),
-	)
-	const typesUpToDate = iconNames.every(name =>
-		currentTypes.includes(`"${name}"`),
-	)
+	const spriteUpToDate = iconNames.every(name => currentSprite.includes(`id=${name}`))
+	const typesUpToDate = iconNames.every(name => currentTypes.includes(`"${name}"`))
 
 	if (spriteUpToDate && typesUpToDate) {
 		logVerbose(`Icons are up to date`)
@@ -69,10 +61,7 @@ async function generateIconFiles() {
 export type IconName =
 \t| ${stringifiedIconNames.join('\n\t| ')};
 `
-	const typesChanged = await writeIfChanged(
-		typeOutputFilepath,
-		typeOutputContent,
-	)
+	const typesChanged = await writeIfChanged(typeOutputFilepath, typeOutputContent)
 
 	logVerbose(`Manifest saved to ${path.relative(cwd, typeOutputFilepath)}`)
 
@@ -143,9 +132,7 @@ async function generateSvgSprite({
 }
 
 async function writeIfChanged(filepath: string, newContent: string) {
-	const currentContent = await fsExtra
-		.readFile(filepath, 'utf8')
-		.catch(() => '')
+	const currentContent = await fsExtra.readFile(filepath, 'utf8').catch(() => '')
 	if (currentContent === newContent) return false
 	await fsExtra.writeFile(filepath, newContent, 'utf8')
 	await $`prettier --write ${filepath} --ignore-unknown`

--- a/other/sentry-create-release.js
+++ b/other/sentry-create-release.js
@@ -13,7 +13,5 @@ if (
 ) {
 	createRelease({}, DEFAULT_URL_PREFIX, DEFAULT_BUILD_PATH)
 } else {
-	console.log(
-		'Missing Sentry environment variables, skipping sourcemap upload.',
-	)
+	console.log('Missing Sentry environment variables, skipping sourcemap upload.')
 }

--- a/remix.config.js
+++ b/remix.config.js
@@ -13,12 +13,7 @@ export default {
 	watchPaths: ['./tailwind.config.ts'],
 	routes: async defineRoutes => {
 		return flatRoutes('routes', defineRoutes, {
-			ignoredRouteFiles: [
-				'.*',
-				'**/*.css',
-				'**/*.test.{js,jsx,ts,tsx}',
-				'**/__*.*',
-			],
+			ignoredRouteFiles: ['.*', '**/*.css', '**/*.test.{js,jsx,ts,tsx}', '**/__*.*'],
 		})
 	},
 }

--- a/remix.init/index.mjs
+++ b/remix.init/index.mjs
@@ -39,15 +39,9 @@ export default async function main({ rootDirectory }) {
 
 	const newEnv = env
 		.replace(/^SESSION_SECRET=.*$/m, `SESSION_SECRET="${getRandomString(16)}"`)
-		.replace(
-			/^INTERNAL_COMMAND_TOKEN=.*$/m,
-			`INTERNAL_COMMAND_TOKEN="${getRandomString(16)}"`,
-		)
+		.replace(/^INTERNAL_COMMAND_TOKEN=.*$/m, `INTERNAL_COMMAND_TOKEN="${getRandomString(16)}"`)
 
-	const newFlyTomlContent = flyTomlContent.replace(
-		new RegExp(appNameRegex, 'g'),
-		APP_NAME,
-	)
+	const newFlyTomlContent = flyTomlContent.replace(new RegExp(appNameRegex, 'g'), APP_NAME)
 
 	const packageJson = JSON.parse(packageJsonString)
 
@@ -148,14 +142,9 @@ async function setupDeployment({ rootDirectory }) {
 	console.log('🔎 Determining the best region for you...')
 	const primaryRegion = await getPreferredRegion()
 
-	const flyConfig = toml.parse(
-		await fs.readFile(path.join(rootDirectory, 'fly.toml')),
-	)
+	const flyConfig = toml.parse(await fs.readFile(path.join(rootDirectory, 'fly.toml')))
 	flyConfig.primary_region = primaryRegion
-	await fs.writeFile(
-		path.join(rootDirectory, 'fly.toml'),
-		toml.stringify(flyConfig),
-	)
+	await fs.writeFile(path.join(rootDirectory, 'fly.toml'), toml.stringify(flyConfig))
 
 	const { app: APP_NAME } = flyConfig
 
@@ -231,9 +220,7 @@ async function setupDeployment({ rootDirectory }) {
 		// any errors and hope things work out.
 		await $I`git init`.catch(() => {})
 
-		console.log(
-			`Opening repo.new. Please create a new repo and paste the URL below.`,
-		)
+		console.log(`Opening repo.new. Please create a new repo and paste the URL below.`)
 		await open(`https://repo.new`)
 
 		const { repoURL } = await inquirer.prompt([

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,11 +5,7 @@ import {
 	createRequestHandler as _createRequestHandler,
 	type RequestHandler,
 } from '@remix-run/express'
-import {
-	broadcastDevReady,
-	installGlobals,
-	type ServerBuild,
-} from '@remix-run/node'
+import { broadcastDevReady, installGlobals, type ServerBuild } from '@remix-run/node'
 import { wrapExpressCreateRequestHandler } from '@sentry/remix'
 import { ip as ipAddress } from 'address'
 import chalk from 'chalk'
@@ -25,9 +21,7 @@ installGlobals()
 
 const MODE = process.env.NODE_ENV
 
-const createRequestHandler = wrapExpressCreateRequestHandler(
-	_createRequestHandler,
-)
+const createRequestHandler = wrapExpressCreateRequestHandler(_createRequestHandler)
 
 const BUILD_PATH = '../build/index.js'
 const WATCH_PATH = '../build/version.txt'
@@ -77,16 +71,10 @@ app.use(compression())
 app.disable('x-powered-by')
 
 // Remix fingerprints its assets so we can cache forever.
-app.use(
-	'/build',
-	express.static('public/build', { immutable: true, maxAge: '1y' }),
-)
+app.use('/build', express.static('public/build', { immutable: true, maxAge: '1y' }))
 
 // Aggressively cache fonts for a year
-app.use(
-	'/fonts',
-	express.static('public/fonts', { immutable: true, maxAge: '1y' }),
-)
+app.use('/fonts', express.static('public/fonts', { immutable: true, maxAge: '1y' }))
 
 // Everything else (like favicon.ico) is cached for an hour. You may want to be
 // more aggressive with this caching.
@@ -149,8 +137,7 @@ app.use(
 // When running tests or running in development, we want to effectively disable
 // rate limiting because playwright tests are very fast and we don't want to
 // have to wait for the rate limit to reset between tests.
-const maxMultiple =
-	MODE !== 'production' || process.env.PLAYWRIGHT_TEST_BASE_URL ? 10_000 : 1
+const maxMultiple = MODE !== 'production' || process.env.PLAYWRIGHT_TEST_BASE_URL ? 10_000 : 1
 const rateLimitDefault = {
 	windowMs: 60 * 1000,
 	max: 1000 * maxMultiple,
@@ -224,17 +211,11 @@ const portToUse = await getPort({
 const server = app.listen(portToUse, () => {
 	const addy = server.address()
 	const portUsed =
-		desiredPort === portToUse
-			? desiredPort
-			: addy && typeof addy === 'object'
-			? addy.port
-			: 0
+		desiredPort === portToUse ? desiredPort : addy && typeof addy === 'object' ? addy.port : 0
 
 	if (portUsed !== desiredPort) {
 		console.warn(
-			chalk.yellow(
-				`⚠️  Port ${desiredPort} is not available, using ${portUsed} instead.`,
-			),
+			chalk.yellow(`⚠️  Port ${desiredPort} is not available, using ${portUsed} instead.`),
 		)
 	}
 	console.log(`🚀  We have liftoff!`)

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -101,13 +101,7 @@ export async function getUserImages() {
 	return userImages
 }
 
-export async function img({
-	altText,
-	filepath,
-}: {
-	altText?: string
-	filepath: string
-}) {
+export async function img({ altText, filepath }: { altText?: string; filepath: string }) {
 	return {
 		altText,
 		contentType: filepath.endsWith('.png') ? 'image/png' : 'image/jpeg',
@@ -124,9 +118,7 @@ export async function cleanupDb(prisma: PrismaClient) {
 		// Disable FK constraints to avoid relation conflicts during deletion
 		prisma.$executeRawUnsafe(`PRAGMA foreign_keys = OFF`),
 		// Delete all rows from each table, preserving table structures
-		...tables.map(({ name }) =>
-			prisma.$executeRawUnsafe(`DELETE from "${name}"`),
-		),
+		...tables.map(({ name }) => prisma.$executeRawUnsafe(`DELETE from "${name}"`)),
 		prisma.$executeRawUnsafe(`PRAGMA foreign_keys = ON`),
 	])
 }

--- a/tests/e2e/2fa.test.ts
+++ b/tests/e2e/2fa.test.ts
@@ -2,10 +2,7 @@ import { faker } from '@faker-js/faker'
 import { generateTOTP } from '#app/utils/totp.server.ts'
 import { expect, test } from '#tests/playwright-utils.ts'
 
-test('Users can add 2FA to their account and use it when logging in', async ({
-	page,
-	login,
-}) => {
+test('Users can add 2FA to their account and use it when logging in', async ({ page, login }) => {
 	const password = faker.internet.password()
 	const user = await login({ password })
 	await page.goto('/settings/profile')
@@ -15,16 +12,12 @@ test('Users can add 2FA to their account and use it when logging in', async ({
 	await expect(page).toHaveURL(`/settings/profile/two-factor`)
 	const main = page.getByRole('main')
 	await main.getByRole('button', { name: /enable 2fa/i }).click()
-	const otpUriString = await main
-		.getByLabel(/One-Time Password URI/i)
-		.innerText()
+	const otpUriString = await main.getByLabel(/One-Time Password URI/i).innerText()
 
 	const otpUri = new URL(otpUriString)
 	const options = Object.fromEntries(otpUri.searchParams)
 
-	await main
-		.getByRole('textbox', { name: /code/i })
-		.fill(generateTOTP(options).otp)
+	await main.getByRole('textbox', { name: /code/i }).fill(generateTOTP(options).otp)
 	await main.getByRole('button', { name: /submit/i }).click()
 
 	await expect(main).toHaveText(/You have enabled two-factor authentication./i)
@@ -40,13 +33,9 @@ test('Users can add 2FA to their account and use it when logging in', async ({
 	await page.getByLabel(/^password$/i).fill(password)
 	await page.getByRole('button', { name: /log in/i }).click()
 
-	await page
-		.getByRole('textbox', { name: /code/i })
-		.fill(generateTOTP(options).otp)
+	await page.getByRole('textbox', { name: /code/i }).fill(generateTOTP(options).otp)
 
 	await page.getByRole('button', { name: /submit/i }).click()
 
-	await expect(
-		page.getByRole('link', { name: user.name ?? user.username }),
-	).toBeVisible()
+	await expect(page.getByRole('link', { name: user.name ?? user.username })).toBeVisible()
 })

--- a/tests/e2e/notes.test.ts
+++ b/tests/e2e/notes.test.ts
@@ -30,15 +30,11 @@ test('Users can edit notes', async ({ page, login }) => {
 	await page.getByRole('link', { name: 'Edit', exact: true }).click()
 	const updatedNote = createNote()
 	await page.getByRole('textbox', { name: /title/i }).fill(updatedNote.title)
-	await page
-		.getByRole('textbox', { name: /content/i })
-		.fill(updatedNote.content)
+	await page.getByRole('textbox', { name: /content/i }).fill(updatedNote.content)
 	await page.getByRole('button', { name: /submit/i }).click()
 
 	await expect(page).toHaveURL(new RegExp(`/users/${user.username}/notes/.*`))
-	await expect(
-		page.getByRole('heading', { name: updatedNote.title }),
-	).toBeVisible()
+	await expect(page.getByRole('heading', { name: updatedNote.title })).toBeVisible()
 })
 
 test('Users can delete notes', async ({ page, login }) => {
@@ -51,16 +47,10 @@ test('Users can delete notes', async ({ page, login }) => {
 	await page.goto(`/users/${user.username}/notes/${note.id}`)
 
 	// find links with href prefix
-	const noteLinks = page
-		.getByRole('main')
-		.getByRole('list')
-		.getByRole('listitem')
-		.getByRole('link')
+	const noteLinks = page.getByRole('main').getByRole('list').getByRole('listitem').getByRole('link')
 	const countBefore = await noteLinks.count()
 	await page.getByRole('button', { name: /delete/i }).click()
-	await expect(
-		page.getByText('Your note has been deleted.', { exact: true }),
-	).toBeVisible()
+	await expect(page.getByText('Your note has been deleted.', { exact: true })).toBeVisible()
 	await expect(page).toHaveURL(`/users/${user.username}/notes`)
 	const countAfter = await noteLinks.count()
 	expect(countAfter).toEqual(countBefore - 1)

--- a/tests/e2e/onboarding.test.ts
+++ b/tests/e2e/onboarding.test.ts
@@ -52,9 +52,7 @@ test('onboarding with link', async ({ page, getOnboardingData }) => {
 	await emailTextbox.fill(onboardingData.email)
 
 	await page.getByRole('button', { name: /submit/i }).click()
-	await expect(
-		page.getByRole('button', { name: /submit/i, disabled: true }),
-	).toBeVisible()
+	await expect(page.getByRole('button', { name: /submit/i, disabled: true })).toBeVisible()
 	await expect(page.getByText(/check your email/i)).toBeVisible()
 
 	const email = await readEmail(onboardingData.email)
@@ -74,9 +72,7 @@ test('onboarding with link', async ({ page, getOnboardingData }) => {
 		.click()
 
 	await expect(page).toHaveURL(`/onboarding`)
-	await page
-		.getByRole('textbox', { name: /^username/i })
-		.fill(onboardingData.username)
+	await page.getByRole('textbox', { name: /^username/i }).fill(onboardingData.username)
 
 	await page.getByRole('textbox', { name: /^name/i }).fill(onboardingData.name)
 
@@ -112,9 +108,7 @@ test('onboarding with a short code', async ({ page, getOnboardingData }) => {
 	await emailTextbox.fill(onboardingData.email)
 
 	await page.getByRole('button', { name: /submit/i }).click()
-	await expect(
-		page.getByRole('button', { name: /submit/i, disabled: true }),
-	).toBeVisible()
+	await expect(page.getByRole('button', { name: /submit/i, disabled: true })).toBeVisible()
 	await expect(page.getByText(/check your email/i)).toBeVisible()
 
 	const email = await readEmail(onboardingData.email)
@@ -153,9 +147,7 @@ test('reset password with a link', async ({ page, insertNewUser }) => {
 	await page.getByRole('link', { name: /forgot password/i }).click()
 	await expect(page).toHaveURL('/forgot-password')
 
-	await expect(
-		page.getByRole('heading', { name: /forgot password/i }),
-	).toBeVisible()
+	await expect(page.getByRole('heading', { name: /forgot password/i })).toBeVisible()
 	await page.getByRole('textbox', { name: /username/i }).fill(user.username)
 	await page.getByRole('button', { name: /recover password/i }).click()
 	await expect(
@@ -185,9 +177,7 @@ test('reset password with a link', async ({ page, insertNewUser }) => {
 	await page.getByLabel(/^confirm password$/i).fill(newPassword)
 
 	await page.getByRole('button', { name: /reset password/i }).click()
-	await expect(
-		page.getByRole('button', { name: /reset password/i, disabled: true }),
-	).toBeVisible()
+	await expect(page.getByRole('button', { name: /reset password/i, disabled: true })).toBeVisible()
 
 	await expect(page).toHaveURL('/login')
 	await page.getByRole('textbox', { name: /username/i }).fill(user.username)
@@ -211,9 +201,7 @@ test('reset password with a short code', async ({ page, insertNewUser }) => {
 	await page.getByRole('link', { name: /forgot password/i }).click()
 	await expect(page).toHaveURL('/forgot-password')
 
-	await expect(
-		page.getByRole('heading', { name: /forgot password/i }),
-	).toBeVisible()
+	await expect(page.getByRole('heading', { name: /forgot password/i })).toBeVisible()
 	await page.getByRole('textbox', { name: /username/i }).fill(user.username)
 	await page.getByRole('button', { name: /recover password/i }).click()
 	await expect(

--- a/tests/e2e/search.test.ts
+++ b/tests/e2e/search.test.ts
@@ -8,9 +8,7 @@ test('Search from home page', async ({ page, insertNewUser }) => {
 	await page.getByRole('searchbox', { name: /search/i }).fill(newUser.username)
 	await page.getByRole('button', { name: /search/i }).click()
 
-	await page.waitForURL(
-		`/users?${new URLSearchParams({ search: newUser.username })}`,
-	)
+	await page.waitForURL(`/users?${new URLSearchParams({ search: newUser.username })}`)
 	await expect(page.getByText('Epic Notes Users')).toBeVisible()
 	const userList = page.getByRole('main').getByRole('list')
 	await expect(userList.getByRole('listitem')).toHaveCount(1)

--- a/tests/e2e/settings-profile.test.ts
+++ b/tests/e2e/settings-profile.test.ts
@@ -14,9 +14,7 @@ test('Users can update their basic info', async ({ page, login }) => {
 	const newUserData = createUser()
 
 	await page.getByRole('textbox', { name: /^name/i }).fill(newUserData.name)
-	await page
-		.getByRole('textbox', { name: /^username/i })
-		.fill(newUserData.username)
+	await page.getByRole('textbox', { name: /^username/i }).fill(newUserData.username)
 
 	await page.getByRole('button', { name: /^save/i }).click()
 })
@@ -29,27 +27,21 @@ test('Users can update their password', async ({ page, login }) => {
 
 	await page.getByRole('link', { name: /change password/i }).click()
 
-	await page
-		.getByRole('textbox', { name: /^current password/i })
-		.fill(oldPassword)
+	await page.getByRole('textbox', { name: /^current password/i }).fill(oldPassword)
 	await page.getByRole('textbox', { name: /^new password/i }).fill(newPassword)
-	await page
-		.getByRole('textbox', { name: /^confirm new password/i })
-		.fill(newPassword)
+	await page.getByRole('textbox', { name: /^confirm new password/i }).fill(newPassword)
 
 	await page.getByRole('button', { name: /^change password/i }).click()
 
 	await expect(page).toHaveURL(`/settings/profile`)
 
 	const { username } = user
-	expect(
-		await verifyUserPassword({ username }, oldPassword),
-		'Old password still works',
-	).toEqual(null)
-	expect(
-		await verifyUserPassword({ username }, newPassword),
-		'New password does not work',
-	).toEqual({ id: user.id })
+	expect(await verifyUserPassword({ username }, oldPassword), 'Old password still works').toEqual(
+		null,
+	)
+	expect(await verifyUserPassword({ username }, newPassword), 'New password does not work').toEqual(
+		{ id: user.id },
+	)
 })
 
 test('Users can update their profile photo', async ({ page, login }) => {
@@ -70,10 +62,9 @@ test('Users can update their profile photo', async ({ page, login }) => {
 
 	await page.getByRole('button', { name: /save/i }).click()
 
-	await expect(
-		page,
-		'Was not redirected after saving the profile photo',
-	).toHaveURL(`/settings/profile`)
+	await expect(page, 'Was not redirected after saving the profile photo').toHaveURL(
+		`/settings/profile`,
+	)
 
 	const afterSrc = await page
 		.getByRole('img', { name: user.name ?? user.username })

--- a/tests/mocks/github.ts
+++ b/tests/mocks/github.ts
@@ -10,12 +10,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const here = (...s: Array<string>) => path.join(__dirname, ...s)
 
 const githubUserFixturePath = path.join(
-	here(
-		'..',
-		'fixtures',
-		'github',
-		`users.${process.env.VITEST_POOL_ID || 0}.local.json`,
-	),
+	here('..', 'fixtures', 'github', `users.${process.env.VITEST_POOL_ID || 0}.local.json`),
 )
 
 await fsExtra.ensureDir(path.dirname(githubUserFixturePath))
@@ -102,9 +97,7 @@ export async function insertGitHubUser(code?: string | null) {
 }
 
 async function getUser(request: Request) {
-	const accessToken = request.headers
-		.get('authorization')
-		?.slice('token '.length)
+	const accessToken = request.headers.get('authorization')?.slice('token '.length)
 
 	if (!accessToken) {
 		return new Response('Unauthorized', { status: 401 })
@@ -117,31 +110,27 @@ async function getUser(request: Request) {
 	return user
 }
 
-const passthroughGitHub =
-	!process.env.GITHUB_CLIENT_ID.startsWith('MOCK_') && !process.env.TESTING
+const passthroughGitHub = !process.env.GITHUB_CLIENT_ID.startsWith('MOCK_') && !process.env.TESTING
 export const handlers: Array<HttpHandler> = [
-	http.post(
-		'https://github.com/login/oauth/access_token',
-		async ({ request }) => {
-			if (passthroughGitHub) return passthrough()
-			const params = new URLSearchParams(await request.text())
+	http.post('https://github.com/login/oauth/access_token', async ({ request }) => {
+		if (passthroughGitHub) return passthrough()
+		const params = new URLSearchParams(await request.text())
 
-			const code = params.get('code')
-			const githubUsers = await getGitHubUsers()
-			let user = githubUsers.find(u => u.code === code)
-			if (!user) {
-				user = await insertGitHubUser(code)
-			}
+		const code = params.get('code')
+		const githubUsers = await getGitHubUsers()
+		let user = githubUsers.find(u => u.code === code)
+		if (!user) {
+			user = await insertGitHubUser(code)
+		}
 
-			return new Response(
-				new URLSearchParams({
-					access_token: user.accessToken,
-					token_type: '__MOCK_TOKEN_TYPE__',
-				}).toString(),
-				{ headers: { 'content-type': 'application/x-www-form-urlencoded' } },
-			)
-		},
-	),
+		return new Response(
+			new URLSearchParams({
+				access_token: user.accessToken,
+				token_type: '__MOCK_TOKEN_TYPE__',
+			}).toString(),
+			{ headers: { 'content-type': 'application/x-www-form-urlencoded' } },
+		)
+	}),
 	http.get('https://api.github.com/user/emails', async ({ request }) => {
 		if (passthroughGitHub) return passthrough()
 
@@ -153,9 +142,7 @@ export const handlers: Array<HttpHandler> = [
 	http.get('https://api.github.com/user/:id', async ({ params }) => {
 		if (passthroughGitHub) return passthrough()
 
-		const mockUser = (await getGitHubUsers()).find(
-			u => u.profile.id === params.id,
-		)
+		const mockUser = (await getGitHubUsers()).find(u => u.profile.id === params.id)
 		if (mockUser) return json(mockUser.profile)
 
 		return new Response('Not Found', { status: 404 })

--- a/tests/mocks/index.ts
+++ b/tests/mocks/index.ts
@@ -10,11 +10,7 @@ const miscHandlers = [
 		: null,
 ].filter(Boolean)
 
-export const server = setupServer(
-	...miscHandlers,
-	...resendHandlers,
-	...githubHandlers,
-)
+export const server = setupServer(...miscHandlers, ...resendHandlers, ...githubHandlers)
 
 server.listen({ onUnhandledRequest: 'warn' })
 

--- a/tests/mocks/utils.ts
+++ b/tests/mocks/utils.ts
@@ -10,11 +10,7 @@ export async function readFixture(subdir: string, name: string) {
 	return fsExtra.readJSON(path.join(fixturesDirPath, subdir, `${name}.json`))
 }
 
-export async function createFixture(
-	subdir: string,
-	name: string,
-	data: unknown,
-) {
+export async function createFixture(subdir: string, name: string, data: unknown) {
 	const dir = path.join(fixturesDirPath, subdir)
 	await fsExtra.ensureDir(dir)
 	return fsExtra.writeJSON(path.join(dir, `./${name}.json`), data)
@@ -52,14 +48,8 @@ export async function readEmail(recipient: string) {
 
 export function requireHeader(headers: Headers, header: string) {
 	if (!headers.has(header)) {
-		const headersString = JSON.stringify(
-			Object.fromEntries(headers.entries()),
-			null,
-			2,
-		)
-		throw new Error(
-			`Header "${header}" required, but not found in ${headersString}`,
-		)
+		const headersString = JSON.stringify(Object.fromEntries(headers.entries()), null, 2)
+		throw new Error(`Header "${header}" required, but not found in ${headersString}`)
 	}
 	return headers.get(header)
 }

--- a/tests/playwright-utils.ts
+++ b/tests/playwright-utils.ts
@@ -1,11 +1,7 @@
 import { test as base } from '@playwright/test'
 import { type User as UserModel } from '@prisma/client'
 import * as setCookieParser from 'set-cookie-parser'
-import {
-	getPasswordHash,
-	getSessionExpirationDate,
-	sessionKey,
-} from '#app/utils/auth.server.ts'
+import { getPasswordHash, getSessionExpirationDate, sessionKey } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { authSessionStorage } from '#app/utils/session.server.ts'
 import { createUser } from './db-utils.ts'
@@ -87,9 +83,7 @@ export const test = base.extend<{
 			const cookieConfig = setCookieParser.parseString(
 				await authSessionStorage.commitSession(authSession),
 			) as any
-			await page
-				.context()
-				.addCookies([{ ...cookieConfig, domain: 'localhost' }])
+			await page.context().addCookies([{ ...cookieConfig, domain: 'localhost' }])
 			return user
 		})
 		await prisma.user.deleteMany({ where: { id: userId } })
@@ -106,10 +100,7 @@ export const { expect } = test
  */
 export async function waitFor<ReturnValue>(
 	cb: () => ReturnValue | Promise<ReturnValue>,
-	{
-		errorMessage,
-		timeout = 5000,
-	}: { errorMessage?: string; timeout?: number } = {},
+	{ errorMessage, timeout = 5000 }: { errorMessage?: string; timeout?: number } = {},
 ) {
 	const endTime = Date.now() + timeout
 	let lastError: unknown = new Error(errorMessage)

--- a/tests/setup/custom-matchers.ts
+++ b/tests/setup/custom-matchers.ts
@@ -3,11 +3,7 @@ import { expect } from 'vitest'
 import { sessionKey } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { authSessionStorage } from '#app/utils/session.server.ts'
-import {
-	type OptionalToast,
-	toastSessionStorage,
-	toastKey,
-} from '#app/utils/toast.server.ts'
+import { type OptionalToast, toastSessionStorage, toastKey } from '#app/utils/toast.server.ts'
 import { convertSetCookieToCookie } from '#tests/utils.ts'
 
 import '@testing-library/jest-dom/vitest'
@@ -21,12 +17,8 @@ expect.extend({
 				pass: Boolean(location),
 				message: () =>
 					`Expected response to ${this.isNot ? 'not ' : ''}redirect${
-						redirectToSupplied
-							? ` to ${this.utils.printExpected(redirectTo)}`
-							: ''
-					} but got ${
-						location ? 'no redirect' : this.utils.printReceived(location)
-					}`,
+						redirectToSupplied ? ` to ${this.utils.printExpected(redirectTo)}` : ''
+					} but got ${location ? 'no redirect' : this.utils.printReceived(location)}`,
 			}
 		}
 		const isRedirectStatusCode = response.status >= 300 && response.status < 400
@@ -34,9 +26,7 @@ expect.extend({
 			return {
 				pass: false,
 				message: () =>
-					`Expected redirect to ${
-						this.isNot ? 'not ' : ''
-					}be ${this.utils.printExpected(
+					`Expected redirect to ${this.isNot ? 'not ' : ''}be ${this.utils.printExpected(
 						'>= 300 && < 400',
 					)} but got ${this.utils.printReceived(response.status)}`,
 			}
@@ -44,9 +34,7 @@ expect.extend({
 
 		function toUrl(s?: string | null) {
 			s ??= ''
-			return s.startsWith('http')
-				? new URL(s)
-				: new URL(s, 'https://example.com')
+			return s.startsWith('http') ? new URL(s) : new URL(s, 'https://example.com')
 		}
 
 		function urlsMatch(u1: URL, u2: URL) {
@@ -63,12 +51,9 @@ expect.extend({
 		}
 
 		return {
-			pass:
-				location == redirectTo || urlsMatch(toUrl(location), toUrl(redirectTo)),
+			pass: location == redirectTo || urlsMatch(toUrl(location), toUrl(redirectTo)),
 			message: () =>
-				`Expected response to ${
-					this.isNot ? 'not ' : ''
-				}redirect to ${this.utils.printExpected(
+				`Expected response to ${this.isNot ? 'not ' : ''}redirect to ${this.utils.printExpected(
 					redirectTo,
 				)} but got ${this.utils.printReceived(location)}`,
 		}
@@ -82,10 +67,7 @@ expect.extend({
 		if (!sessionSetCookie) {
 			return {
 				pass: false,
-				message: () =>
-					`The en_session set-cookie header was${
-						this.isNot ? '' : ' not'
-					} defined`,
+				message: () => `The en_session set-cookie header was${this.isNot ? '' : ' not'} defined`,
 			}
 		}
 
@@ -109,22 +91,17 @@ expect.extend({
 		return {
 			pass: Boolean(session),
 			message: () =>
-				`A session was${
-					this.isNot ? ' not' : ''
-				} created in the database for ${userId}`,
+				`A session was${this.isNot ? ' not' : ''} created in the database for ${userId}`,
 		}
 	},
 	async toSendToast(response: Response, toast: OptionalToast) {
 		const setCookies = getSetCookie(response.headers)
-		const toastSetCookie = setCookies.find(
-			c => setCookieParser.parseString(c).name === 'en_toast',
-		)
+		const toastSetCookie = setCookies.find(c => setCookieParser.parseString(c).name === 'en_toast')
 
 		if (!toastSetCookie) {
 			return {
 				pass: false,
-				message: () =>
-					`en_toast set-cookie header was${this.isNot ? '' : ' not'} defined`,
+				message: () => `en_toast set-cookie header was${this.isNot ? '' : ' not'} defined`,
 			}
 		}
 

--- a/tests/setup/global-setup.ts
+++ b/tests/setup/global-setup.ts
@@ -2,10 +2,7 @@ import path from 'node:path'
 import { execaCommand } from 'execa'
 import fsExtra from 'fs-extra'
 
-export const BASE_DATABASE_PATH = path.join(
-	process.cwd(),
-	`./tests/prisma/base.db`,
-)
+export const BASE_DATABASE_PATH = path.join(process.cwd(), `./tests/prisma/base.db`)
 
 export async function setup() {
 	const databaseExists = await fsExtra.pathExists(BASE_DATABASE_PATH)

--- a/tests/setup/setup-test-env.ts
+++ b/tests/setup/setup-test-env.ts
@@ -19,12 +19,10 @@ export let consoleError: SpyInstance<Parameters<(typeof console)['error']>>
 beforeEach(() => {
 	const originalConsoleError = console.error
 	consoleError = vi.spyOn(console, 'error')
-	consoleError.mockImplementation(
-		(...args: Parameters<typeof console.error>) => {
-			originalConsoleError(...args)
-			throw new Error(
-				'Console error was called. Call consoleError.mockImplementation(() => {}) if this is expected.',
-			)
-		},
-	)
+	consoleError.mockImplementation((...args: Parameters<typeof console.error>) => {
+		originalConsoleError(...args)
+		throw new Error(
+			'Console error was called. Call consoleError.mockImplementation(() => {}) if this is expected.',
+		)
+	})
 })

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -11,23 +11,14 @@ export function convertSetCookieToCookie(setCookie: string) {
 	}).toString()
 }
 
-export async function getSessionSetCookieHeader(
-	session: { id: string },
-	existingCookie?: string,
-) {
+export async function getSessionSetCookieHeader(session: { id: string }, existingCookie?: string) {
 	const authSession = await authSessionStorage.getSession(existingCookie)
 	authSession.set(sessionKey, session.id)
 	const setCookieHeader = await authSessionStorage.commitSession(authSession)
 	return setCookieHeader
 }
 
-export async function getSessionCookieHeader(
-	session: { id: string },
-	existingCookie?: string,
-) {
-	const setCookieHeader = await getSessionSetCookieHeader(
-		session,
-		existingCookie,
-	)
+export async function getSessionCookieHeader(session: { id: string }, existingCookie?: string) {
+	const setCookieHeader = await getSessionSetCookieHeader(session, existingCookie)
 	return convertSetCookieToCookie(setCookieHeader)
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,10 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "paths": {
       "#*": ["./*"],
-      "@/icon-name": [
-        "./app/components/ui/icons/name.d.ts",
-        "./types/icon-name.d.ts"
-      ]
+      "@/icon-name": ["./app/components/ui/icons/name.d.ts", "./types/icon-name.d.ts"]
     },
     "skipLibCheck": true,
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
I increased the printWidth to 100, except for md files.

I kept it to 80 for md files as a line length of 80 or even shorter is ideal for reading sentences:
https://baymard.com/blog/line-length-readability

However, in my opinion this is not the case with reading code, and it is more important, that doing "1 thing" can fit in "1 line", so that the length of the code gets a better indication of its actual complexity:

<img width="722" alt="image" src="https://github.com/epicweb-dev/epic-stack/assets/1035299/8360fcf2-0155-4693-b36f-bdee06d2d1b1">

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated
