### PR TITLE
Add 404 assertion to e2e error-boundary

### DIFF
--- a/tests/e2e/error-boundary.test.ts
+++ b/tests/e2e/error-boundary.test.ts
@@ -1,8 +1,17 @@
+import { type Request } from '@playwright/test'
 import { expect, test } from '#tests/playwright-utils.ts'
 
 test('Test root error boundary caught', async ({ page }) => {
-	await page.goto('/does-not-exist')
+	const pageUrl = '/does-not-exist'
+	await page.goto(pageUrl)
 
 	await expect(page.getByText(/We can't find this page/i)).toBeVisible()
-	// TODO: figure out how to assert the 404 status code
+
+	const listener = (request: Request) => {
+		if (request.url().includes(pageUrl)) {
+			request.response().then(response => expect(response?.status()).toBe(404))
+		}
+	}
+
+	page.on('request', listener)
 })

--- a/tests/e2e/error-boundary.test.ts
+++ b/tests/e2e/error-boundary.test.ts
@@ -1,17 +1,9 @@
-import { type Request } from '@playwright/test'
 import { expect, test } from '#tests/playwright-utils.ts'
 
 test('Test root error boundary caught', async ({ page }) => {
 	const pageUrl = '/does-not-exist'
-	await page.goto(pageUrl)
+	const res = await page.goto(pageUrl)
 
+	expect(res?.status()).toBe(404)
 	await expect(page.getByText(/We can't find this page/i)).toBeVisible()
-
-	const listener = (request: Request) => {
-		if (request.url().includes(pageUrl)) {
-			request.response().then(response => expect(response?.status()).toBe(404))
-		}
-	}
-
-	page.on('request', listener)
 })


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
I noticed a `// todo: figure out` which seemed a nice little challenge. Add a listener to verify the 404

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->
- Checkout branch
- Run e2e tests

## Checklist

- [ x ] Tests updated
- [ n/a ] Docs updated
