### PR TITLE
fix: handling when session exists but user doesn't exist in db

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -45,7 +45,7 @@ import {
 import { Icon, href as iconsHref } from './components/ui/icon.tsx'
 import fontStyleSheetUrl from './styles/font.css'
 import tailwindStyleSheetUrl from './styles/tailwind.css'
-import { authenticator, getUserId } from './utils/auth.server.ts'
+import { getUserId, logout } from './utils/auth.server.ts'
 import { ClientHintCheck, getHints, useHints } from './utils/client-hints.tsx'
 import { getConfetti } from './utils/confetti.server.ts'
 import { csrf } from './utils/csrf.server.ts'
@@ -130,7 +130,7 @@ export async function loader({ request }: DataFunctionArgs) {
 		console.info('something weird happened')
 		// something weird happened... The user is authenticated but we can't find
 		// them in the database. Maybe they were deleted? Let's log them out.
-		await authenticator.logout(request, { redirectTo: '/' })
+		await logout({ request, redirectTo: '/' })
 	}
 	const { toast, headers: toastHeaders } = await getToast(request)
 	const { confettiId, headers: confettiHeaders } = getConfetti(request)

--- a/app/routes/me.tsx
+++ b/app/routes/me.tsx
@@ -1,5 +1,5 @@
 import { redirect, type DataFunctionArgs } from '@remix-run/node'
-import { authenticator, requireUserId } from '#app/utils/auth.server.ts'
+import { requireUserId, logout } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 
 export async function loader({ request }: DataFunctionArgs) {
@@ -11,7 +11,7 @@ export async function loader({ request }: DataFunctionArgs) {
 			['redirectTo', `${requestUrl.pathname}${requestUrl.search}`],
 		])
 		const redirectTo = `/login?${loginParams}`
-		await authenticator.logout(request, { redirectTo })
+		await logout({ request, redirectTo })
 		return redirect(redirectTo)
 	}
 	return redirect(`/users/${user.username}`)


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
change handling from `authenticator.logout()` to `logout()`.

**Why**
 This process is intended to remove invalid session about userId on both cookie and db sides, when userId which get from session doesn't exists in db.
 We manage userId in `authSessionStorage` now. On the other hand, authenticator handle connection, which is stored in `connectionSessionStorage`. Therefore, even after `authenticator.logout()`, the information about the userId remains. This can cause infinite redirect. I think this is left over from the process when remix-auth and remix-auth-form were used for authentication.
 Replace `authenticator.logout()` with `logout()`, but if necessary, I will add the process to destory connectionSession manually.
For example:
```tsx
import { connectionSessionStorage } from '#app/utils/connections.server.ts'
// in action code.
const connectioSession = await connectionSessionStorage.getSession(
  request.headers.get('cookie'),
)
const responseInit = {
  headers: { 'set-cookie': connectionSessionStorage.destroySession(connectioSession) }
}
await logout({ request }, responseInit)
```

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
