### PR TITLE
fix: `json` import

### DIFF
--- a/app/routes/users+/$username_+/notes.new.tsx
+++ b/app/routes/users+/$username_+/notes.new.tsx
@@ -1,4 +1,4 @@
-import { json } from '@remix-run/router'
+import { json } from '@remix-run/node'
 import { type DataFunctionArgs } from '@remix-run/server-runtime'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { NoteEditor, action } from './__note-editor.tsx'


### PR DESCRIPTION
This PR fixes the import of `json` helper function from Remix, which should come from `@remix-run/node` to maintain consistency with all the other files.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
