### PR TITLE
feat(vscode): prompt to use TS from workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,7 @@
   ],
   "workbench.editorAssociations": {
     "*.db": "sqlite-viewer.view"
-  }
+  },
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
 }


### PR DESCRIPTION
This PR adds two new settings to the VS Code workspace settings.

**Without these settings, VS Code uses its internal TS version, which can differ from the workspace. This could result in different errors/warnings shown in the editor and `npm run typecheck`.**

1. `typescript.tsdk`
  - VS Code setting description: Specifies the folder path to the tsserver and lib*.d.ts files under a TypeScript install to use for IntelliSense, for example: ./node_modules/typescript/lib. **When specified as a workspace setting, typescript.tsdk allows you to switch to use that workspace version of TypeScript for IntelliSense with the TypeScript: Select TypeScript version command.**
2. `typescript.enablePromptUseWorkspaceTsdk`
  - VS Code setting description: **Enables prompting of users to use the TypeScript version configured in the workspace for Intellisense.**
  - Related to the `typescript.tsdk` option, this results in this popup when opening the workspace: 
<img width="469" alt="Screenshot 2023-11-07 at 12 34 31" src="https://github.com/epicweb-dev/epic-stack/assets/57627858/6c92addd-e183-4560-8e92-09f67b00b02e">


## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
