### PR TITLE
Rese getPasswordHash function in resetUserPassword

### DIFF
--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -96,7 +96,7 @@ export async function resetUserPassword({
 	username: User['username']
 	password: string
 }) {
-	const hashedPassword = await bcrypt.hash(password, 10)
+	const hashedPassword = await getPasswordHash(password);
 	return prisma.user.update({
 		where: { username },
 		data: {


### PR DESCRIPTION
<!-- Summary: Put your summary here -->

Reuse the `getPasswordHash` function in `resetUserPassword` instead of using `bcrypt.hash(password, 10)` directly 

## Test Plan


<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
