### PR TITLE
Fixed min-width on forms for mobile

### DIFF
--- a/app/routes/_auth+/forgot-password.tsx
+++ b/app/routes/_auth+/forgot-password.tsx
@@ -140,7 +140,7 @@ export default function ForgotPasswordRoute() {
 						No worries, we'll send you reset instructions.
 					</p>
 				</div>
-				<div className="mx-auto mt-16 min-w-[368px] max-w-sm">
+				<div className="mx-auto mt-16 min-w-full sm:min-w-[368px] max-w-sm">
 					<forgotPassword.Form method="POST" {...form.props}>
 						<AuthenticityTokenInput />
 						<HoneypotInputs />

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -168,7 +168,7 @@ export default function SignupRoute() {
 				<Spacer size="xs" />
 				<Form
 					method="POST"
-					className="mx-auto min-w-[368px] max-w-sm"
+					className="mx-auto min-w-full sm:min-w-[368px] max-w-sm"
 					{...form.props}
 				>
 					<AuthenticityTokenInput />

--- a/app/routes/_auth+/onboarding_.$provider.tsx
+++ b/app/routes/_auth+/onboarding_.$provider.tsx
@@ -209,7 +209,7 @@ export default function SignupRoute() {
 				<Spacer size="xs" />
 				<Form
 					method="POST"
-					className="mx-auto min-w-[368px] max-w-sm"
+					className="mx-auto min-w-full sm:min-w-[368px] max-w-sm"
 					{...form.props}
 				>
 					{fields.imageUrl.defaultValue ? (

--- a/app/routes/_auth+/reset-password.tsx
+++ b/app/routes/_auth+/reset-password.tsx
@@ -113,7 +113,7 @@ export default function ResetPasswordPage() {
 					Hi, {data.resetPasswordUsername}. No worries. It happens all the time.
 				</p>
 			</div>
-			<div className="mx-auto mt-16 min-w-[368px] max-w-sm">
+			<div className="mx-auto mt-16 min-w-full sm:min-w-[368px] max-w-sm">
 				<Form method="POST" {...form.props}>
 					<Field
 						labelProps={{

--- a/app/routes/_auth+/signup.tsx
+++ b/app/routes/_auth+/signup.tsx
@@ -137,7 +137,7 @@ export default function SignupRoute() {
 					Please enter your email.
 				</p>
 			</div>
-			<div className="mx-auto mt-16 min-w-[368px] max-w-sm">
+			<div className="mx-auto mt-16 min-w-full sm:min-w-[368px] max-w-sm">
 				<Form method="POST" {...form.props}>
 					<AuthenticityTokenInput />
 					<HoneypotInputs />


### PR DESCRIPTION
## Summary

Updated the current `min-w-[368px]` to now apply on small screens and above. This was causing the form fields to overflow on mobile.

## Test Plan
https://epicstack.dev/signup can be visited on mobile to view the bug and then the fix can be viewed to compare if the issue has been resolved.

## Checklist

- ❌ Tests updated
- ❌ Docs updated

## Screenshots

|Bug|Fix|
|---|---|
|![image](https://github.com/epicweb-dev/epic-stack/assets/71184799/49875145-7cdf-43e4-8863-989613e8ced9)|![image](https://github.com/epicweb-dev/epic-stack/assets/71184799/77dbb762-8390-400b-bbf2-7146f7fd7b55)|