### PR TITLE
properly ignore healthcheck related transactions to sentry

### DIFF
--- a/app/utils/monitoring.server.ts
+++ b/app/utils/monitoring.server.ts
@@ -22,9 +22,19 @@ export function init() {
 			new Sentry.Integrations.Prisma({ client: prisma }),
 			new ProfilingIntegration(),
 		],
+		tracesSampler(samplingContext) {
+			// ignore healthcheck transactions by other services (consul, etc.)
+			if (samplingContext.request?.url?.includes('/resources/healthcheck')) {
+				return 0
+			}
+			return 1
+		},
 		beforeSendTransaction(event) {
 			// ignore all healthcheck related transactions
-			if (event.request?.headers?.['X-Healthcheck'] === 'true') return null
+			//  note that name of header here is case-sensitive
+			if (event.request?.headers?.['x-healthcheck'] === 'true') {
+				return null
+			}
 
 			return event
 		},


### PR DESCRIPTION
<!-- Summary: Put your summary here -->

When reading 'x-healthcheck' from Sentry event request headers, we can't use `headers.get()` which is case-insensitive. Hence we'd need to use lowercase `x-healthcheck` key to properly check the request header value.

Also when the app is deployed to fly.io, there are other healthcheck events (from Consul) which we need to stop sampling.



## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->

Before
![Screenshot 2023-11-29 at 4 54 51 PM](https://github.com/epicweb-dev/epic-stack/assets/1919336/1010325e-93ce-48e2-a926-ff1b153739bf)


After
![Screenshot 2023-11-29 at 4 55 49 PM](https://github.com/epicweb-dev/epic-stack/assets/1919336/3d6fdb0e-e424-4eb1-8e04-1d1d77112b55)



