### PR TITLE
fix (server): Fix source map retrieval for updated builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import 'dotenv/config'
-import 'source-map-support'
+import ssourceMapSupport from 'source-map-support'
 import { installGlobals } from '@remix-run/node'
 import chalk from 'chalk'
 import closeWithGrace from 'close-with-grace'

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 import 'dotenv/config'
-import ssourceMapSupport from 'source-map-support'
+import * as fs from 'fs'
 import { installGlobals } from '@remix-run/node'
 import chalk from 'chalk'
 import closeWithGrace from 'close-with-grace'
+import sourceMapSupport from 'source-map-support'
 
 sourceMapSupport.install({
 	retrieveSourceMap: function (source) {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,22 @@
 import 'dotenv/config'
-import 'source-map-support/register.js'
+import 'source-map-support'
 import { installGlobals } from '@remix-run/node'
 import chalk from 'chalk'
 import closeWithGrace from 'close-with-grace'
+
+sourceMapSupport.install({
+	retrieveSourceMap: function (source) {
+		// get source file without the `file://` prefix or `?t=...` suffix
+		const match = source.match(/^file:\/\/(.*)\?t=[.\d]+$/)
+		if (match) {
+			return {
+				url: source,
+				map: fs.readFileSync(`${match[1]}.map`, 'utf8'),
+			}
+		}
+		return null
+	},
+})
 
 installGlobals()
 


### PR DESCRIPTION
This PR adds the fix submitted in Remix PR #8174. The issue is caused when the build server imports an updated server build with a ?t=timestamp suffix. This causes the source map support library to fail to load the source map.

https://github.com/remix-run/remix/pull/8174
