### PR TITLE
bugfix: set theme cookie maxAge so it's not a session cookie

### DIFF
--- a/app/utils/theme.server.ts
+++ b/app/utils/theme.server.ts
@@ -14,6 +14,6 @@ export function setTheme(theme: Theme | 'system') {
 	if (theme === 'system') {
 		return cookie.serialize(cookieName, '', { path: '/', maxAge: -1 })
 	} else {
-		return cookie.serialize(cookieName, theme, { path: '/' })
+		return cookie.serialize(cookieName, theme, { path: '/', maxAge: 31536000 })
 	}
 }


### PR DESCRIPTION
Without max age, the cookie would disappear after the current session.