### PR TITLE
Added instructions for connecting to the primary instance

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -67,6 +67,18 @@ you can utilize Fly's `ssh` and `proxy` commands.
   fly proxy 5556:5555 --app [YOUR_APP_NAME]
   ```
 
+If you have multiple instances of your app running, and you'd like to make edits to your database, you will need to run `prisma:studio` on the primary instance.
+
+- Get a list of your app instances, the `ROLE` column will show which instance is `primary`
+   ```sh
+   fly status --app [YOUR_APP_NAME]
+   ```
+- Run the console command with the `-s` select flag
+   ```sh
+  fly ssh console -C "npm run prisma:studio" -s --app [YOUR_APP_NAME]
+  ```
+- Use your arrow keys to select the primary instance
+
 To work with Prisma Studio and your deployed app's database, simply open
 `http://localhost:5556` in your browser.
 


### PR DESCRIPTION
Once you have multiple instances of your app, you may want to connect to the `primary` instance of your database to make edits.

I've updated the docs to include instructions on using the `-s` select flag to run the console command on the primary instance.

## Test Plan

No testing needed, docs update


## Checklist

- [x] Docs updated


