### PR TITLE
Remove redundant and non-existant `border-border`

### DIFF
--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -80,9 +80,6 @@
 }
 
 @layer base {
-	* {
-		@apply border-border;
-	}
 	body {
 		@apply bg-background text-foreground;
 	}


### PR DESCRIPTION
`border-border` doesn't exist, this was probably meant to be `border-box` (https://tailwindcss.com/docs/box-sizing#including-borders-and-padding).

But even that would be redundant, since it is already the default in the preflight syles.
