### PR TITLE
fix: stop removing .git on init

### DIFF
--- a/remix.init/index.mjs
+++ b/remix.init/index.mjs
@@ -68,10 +68,6 @@ export default async function main({ rootDirectory }) {
 		fs.rm(path.join(rootDirectory, 'docs'), { recursive: true }),
 		fs.rm(path.join(rootDirectory, 'tests/e2e/notes.test.ts')),
 		fs.rm(path.join(rootDirectory, 'tests/e2e/search.test.ts')),
-
-		// .git could exist if pointing to a local version of the template rather
-		// than the github version, and there's not any situation we'd want that.
-		fs.rm(path.join(rootDirectory, '.git'), { recursive: true, force: true }),
 	]
 
 	await Promise.all(fileOperationPromises)


### PR DESCRIPTION
Discussed on Discord https://discord.com/channels/715220730605731931/1105271172079300630/1172436921427955743

My usual workflow for creating new projects is to spin up a new repo on Github, clone it to my machine, and then initialize whatever project I have inside it 

The epic stack currently deletes the .git directory in this case 

Another risk factor is if a dev decides to create a new branch of an existing project and runs the setup command, it will delete their .git and all their other branches

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
