### PR TITLE
fix: move border color to tailwind config

### DIFF
--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -78,12 +78,3 @@
 		--ring: 217.2 32.6% 60%;
 	}
 }
-
-@layer base {
-	* {
-		@apply border-border;
-	}
-	body {
-		@apply bg-background text-foreground;
-	}
-}

--- a/app/utils/extended-theme.ts
+++ b/app/utils/extended-theme.ts
@@ -45,6 +45,9 @@ export const extendedTheme = {
 			foreground: 'hsl(var(--card-foreground))',
 		},
 	},
+	borderColor: {
+		DEFAULT: 'hsl(var(--border))',
+	},
 	borderRadius: {
 		lg: 'var(--radius)',
 		md: 'calc(var(--radius) - 2px)',


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
The tailwind config is a better place to put this global color setting for the borders, especially since `.border-border` isn't a very descriptive class

I would also be in favour of removing `border` from the custom colors entirely as I think this is the only place that's used, but that might be a breaking change in case other folks have been using it 

```diff
	colors: {
- 		border: 'hsl(var(--border))',
		input: {
			DEFAULT: 'hsl(var(--input))',
			invalid: 'hsl(var(--input-invalid))',
```

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots
Before this change
<img width="481" alt="image" src="https://github.com/epicweb-dev/epic-stack/assets/5633704/0d318fcb-d0f1-4ead-bb2c-b9c674fa7ce4">

After this change

<img width="475" alt="image" src="https://github.com/epicweb-dev/epic-stack/assets/5633704/ccef3151-7967-43c2-a5e7-97cd480b7106">

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
