### PR TITLE
import `DataFunctionArgs` from `@remix-run/node` instead of `@remix-run/server-runtime`

### DIFF
--- a/app/routes/users+/$username_+/notes.new.tsx
+++ b/app/routes/users+/$username_+/notes.new.tsx
@@ -1,5 +1,4 @@
-import { json } from '@remix-run/node'
-import { type DataFunctionArgs } from '@remix-run/server-runtime'
+import { json , type DataFunctionArgs } from '@remix-run/node'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { NoteEditor, action } from './__note-editor.tsx'
 


### PR DESCRIPTION
Import `DataFunctionArgs` type from `@remix-run/node` instead of `@remix-run/server-runtime` to maintain consistency with the rest of the app.
