### PR TITLE
Lighter color tiles for dark mode

### DIFF
--- a/app/routes/_marketing+/index.tsx
+++ b/app/routes/_marketing+/index.tsx
@@ -84,7 +84,7 @@ export default function Index() {
 									<TooltipTrigger asChild>
 										<a
 											href={logo.href}
-											className="grid size-20 place-items-center rounded-2xl bg-violet-600/10 p-4 transition hover:-rotate-6 hover:bg-violet-600/15 sm:size-24 dark:grayscale dark:hover:grayscale-0"
+											className="grid size-20 place-items-center rounded-2xl bg-violet-600/10 p-4 transition hover:-rotate-6 hover:bg-violet-600/15 sm:size-24 dark:bg-violet-200 dark:hover:bg-violet-100"
 										>
 											<img src={logo.src} alt="" className="w-16" />
 										</a>


### PR DESCRIPTION

Switching to lighter color tiles on dark mode to work better with logos.

https://github.com/epicweb-dev/epic-stack/assets/485747/c670621a-e114-4753-bc89-02c64dbc70e1

