### PR TITLE
fix: add general error boundary on cache routes

### DIFF
--- a/app/routes/admin+/cache.tsx
+++ b/app/routes/admin+/cache.tsx
@@ -14,6 +14,7 @@ import {
 	useSearchParams,
 	useSubmit,
 } from '@remix-run/react'
+import { GeneralErrorBoundary } from '#app/components/error-boundary'
 import { Field } from '#app/components/forms.tsx'
 import { Spacer } from '#app/components/spacer.tsx'
 import { Button } from '#app/components/ui/button.tsx'
@@ -235,8 +236,14 @@ function CacheKeyRow({
 	)
 }
 
-export function ErrorBoundary({ error }: { error: Error }) {
-	console.error(error)
-
-	return <div>An unexpected error occurred: {error.message}</div>
+export function ErrorBoundary() {
+	return (
+		<GeneralErrorBoundary
+			statusHandlers={{
+				403: ({ error }) => (
+					<p>You are not allowed to do that: {error?.data.message}</p>
+				),
+			}}
+		/>
+	)
 }


### PR DESCRIPTION
I've found a way to solve #583 
Basically was missing a `<GeneralErrorBoundary> `component with its error handling component because if you were taking the error from the cache routes was resulting in an undefined result.
The error from general error boundary is an object with inside data that contains the error.
## Test Plan
1. Login to epic stack with a non-admin user
2. Navigate to ./admin/cache route
3. See the correct error being showed
![Screenshot 2024-01-12 at 11 33 56](https://github.com/epicweb-dev/epic-stack/assets/44196268/eca715d9-d46a-406d-a198-654170d92646)

