### PR TITLE
replace LoaderFunction with LoaderFunctionArgs in seo.md

### DIFF
--- a/docs/seo.md
+++ b/docs/seo.md
@@ -31,7 +31,7 @@ export const handle: SEOHandle = {
 // in your routes/url-that-doesnt-need-sitemap
 import { SEOHandle } from '@nasa-gcn/remix-seo'
 
-export let loader: LoaderFunction = ({ request }) => {
+export let loader = ({ request }: LoaderFunctionArgs) => {
 	/**/
 }
 


### PR DESCRIPTION
This is not a huge change, but just to be consistent with the code, since `LoaderFunctionArgs` is used everywhere instead of `LoaderFunction`