### PR TITLE
Migrate to conform v1

### DIFF
--- a/app/routes/_auth+/forgot-password.tsx
+++ b/app/routes/_auth+/forgot-password.tsx
@@ -1,5 +1,5 @@
-import { conform, useForm } from '@conform-to/react'
-import { getFieldsetConstraint, parse } from '@conform-to/zod'
+import { getFormProps, getInputProps, useForm } from '@conform-to/react'
+import { getZodConstraint, parseWithZod } from '@conform-to/zod'
 import * as E from '@react-email/components'
 import {
 	json,
@@ -26,7 +26,7 @@ const ForgotPasswordSchema = z.object({
 export async function action({ request }: ActionFunctionArgs) {
 	const formData = await request.formData()
 	checkHoneypot(formData)
-	const submission = await parse(formData, {
+	const submission = await parseWithZod(formData, {
 		schema: ForgotPasswordSchema.superRefine(async (data, ctx) => {
 			const user = await prisma.user.findFirst({
 				where: {
@@ -48,11 +48,13 @@ export async function action({ request }: ActionFunctionArgs) {
 		}),
 		async: true,
 	})
-	if (submission.intent !== 'submit') {
-		return json({ status: 'idle', submission } as const)
-	}
-	if (!submission.value) {
-		return json({ status: 'error', submission } as const, { status: 400 })
+	if (submission.status !== 'success') {
+		return json(
+			{ result: submission.reply() },
+			{
+				status: submission.status === 'error' ? 400 : 200,
+			},
+		)
 	}
 	const { usernameOrEmail } = submission.value
 
@@ -79,8 +81,14 @@ export async function action({ request }: ActionFunctionArgs) {
 	if (response.status === 'success') {
 		return redirect(redirectTo.toString())
 	} else {
-		submission.error[''] = [response.error.message]
-		return json({ status: 'error', submission } as const, { status: 500 })
+		return json(
+			{
+				result: submission.reply({ formErrors: [response.error.message] }),
+			},
+			{
+				status: 500,
+			},
+		)
 	}
 }
 
@@ -120,10 +128,10 @@ export default function ForgotPasswordRoute() {
 
 	const [form, fields] = useForm({
 		id: 'forgot-password-form',
-		constraint: getFieldsetConstraint(ForgotPasswordSchema),
-		lastSubmission: forgotPassword.data?.submission,
+		constraint: getZodConstraint(ForgotPasswordSchema),
+		lastResult: forgotPassword.data?.result,
 		onValidate({ formData }) {
-			return parse(formData, { schema: ForgotPasswordSchema })
+			return parseWithZod(formData, { schema: ForgotPasswordSchema })
 		},
 		shouldRevalidate: 'onBlur',
 	})
@@ -138,7 +146,7 @@ export default function ForgotPasswordRoute() {
 					</p>
 				</div>
 				<div className="mx-auto mt-16 min-w-full max-w-sm sm:min-w-[368px]">
-					<forgotPassword.Form method="POST" {...form.props}>
+					<forgotPassword.Form method="POST" {...getFormProps(form)}>
 						<HoneypotInputs />
 						<div>
 							<Field
@@ -148,7 +156,7 @@ export default function ForgotPasswordRoute() {
 								}}
 								inputProps={{
 									autoFocus: true,
-									...conform.input(fields.usernameOrEmail),
+									...getInputProps(fields.usernameOrEmail, { type: 'text' }),
 								}}
 								errors={fields.usernameOrEmail.errors}
 							/>
@@ -161,7 +169,7 @@ export default function ForgotPasswordRoute() {
 								status={
 									forgotPassword.state === 'submitting'
 										? 'pending'
-										: forgotPassword.data?.status ?? 'idle'
+										: form.status ?? 'idle'
 								}
 								type="submit"
 								disabled={forgotPassword.state !== 'idle'}

--- a/app/routes/_auth+/login.tsx
+++ b/app/routes/_auth+/login.tsx
@@ -1,5 +1,5 @@
-import { conform, useForm } from '@conform-to/react'
-import { getFieldsetConstraint, parse } from '@conform-to/zod'
+import { useForm, getFormProps, getInputProps } from '@conform-to/react'
+import { getZodConstraint, parseWithZod } from '@conform-to/zod'
 import { invariant } from '@epic-web/invariant'
 import {
 	json,
@@ -110,7 +110,10 @@ export async function handleVerification({
 	request,
 	submission,
 }: VerifyFunctionArgs) {
-	invariant(submission.value, 'Submission should have a value by this point')
+	invariant(
+		submission.status === 'success',
+		'Submission should be successful by now',
+	)
 	const authSession = await authSessionStorage.getSession(
 		request.headers.get('cookie'),
 	)
@@ -196,10 +199,10 @@ export async function action({ request }: ActionFunctionArgs) {
 	await requireAnonymous(request)
 	const formData = await request.formData()
 	checkHoneypot(formData)
-	const submission = await parse(formData, {
+	const submission = await parseWithZod(formData, {
 		schema: intent =>
 			LoginFormSchema.transform(async (data, ctx) => {
-				if (intent !== 'submit') return { ...data, session: null }
+				if (intent !== null) return { ...data, session: null }
 
 				const session = await login(data)
 				if (!session) {
@@ -214,16 +217,18 @@ export async function action({ request }: ActionFunctionArgs) {
 			}),
 		async: true,
 	})
-	// get the password off the payload that's sent back
-	delete submission.payload.password
 
-	if (submission.intent !== 'submit') {
-		// @ts-expect-error - conform should probably have support for doing this
-		delete submission.value?.password
-		return json({ status: 'idle', submission } as const)
-	}
-	if (!submission.value?.session) {
-		return json({ status: 'error', submission } as const, { status: 400 })
+	if (submission.status !== 'success' || !submission.value.session) {
+		return json(
+			{
+				result: submission.reply({
+					hideFields: ['password'],
+				}),
+			},
+			{
+				status: submission.status === 'error' ? 400 : 200,
+			},
+		)
 	}
 
 	const { session, remember, redirectTo } = submission.value
@@ -244,11 +249,11 @@ export default function LoginPage() {
 
 	const [form, fields] = useForm({
 		id: 'login-form',
-		constraint: getFieldsetConstraint(LoginFormSchema),
+		constraint: getZodConstraint(LoginFormSchema),
 		defaultValue: { redirectTo },
-		lastSubmission: actionData?.submission,
+		lastResult: actionData?.result,
 		onValidate({ formData }) {
-			return parse(formData, { schema: LoginFormSchema })
+			return parseWithZod(formData, { schema: LoginFormSchema })
 		},
 		shouldRevalidate: 'onBlur',
 	})
@@ -266,12 +271,12 @@ export default function LoginPage() {
 
 				<div>
 					<div className="mx-auto w-full max-w-md px-8">
-						<Form method="POST" {...form.props}>
+						<Form method="POST" {...getFormProps(form)}>
 							<HoneypotInputs />
 							<Field
 								labelProps={{ children: 'Username' }}
 								inputProps={{
-									...conform.input(fields.username),
+									...getInputProps(fields.username, { type: 'text' }),
 									autoFocus: true,
 									className: 'lowercase',
 									autoComplete: 'username',
@@ -282,7 +287,7 @@ export default function LoginPage() {
 							<Field
 								labelProps={{ children: 'Password' }}
 								inputProps={{
-									...conform.input(fields.password, {
+									...getInputProps(fields.password, {
 										type: 'password',
 									}),
 									autoComplete: 'current-password',
@@ -296,7 +301,7 @@ export default function LoginPage() {
 										htmlFor: fields.remember.id,
 										children: 'Remember me',
 									}}
-									buttonProps={conform.input(fields.remember, {
+									buttonProps={getInputProps(fields.remember, {
 										type: 'checkbox',
 									})}
 									errors={fields.remember.errors}
@@ -312,14 +317,14 @@ export default function LoginPage() {
 							</div>
 
 							<input
-								{...conform.input(fields.redirectTo, { type: 'hidden' })}
+								{...getInputProps(fields.redirectTo, { type: 'hidden' })}
 							/>
 							<ErrorList errors={form.errors} id={form.errorId} />
 
 							<div className="flex items-center justify-between gap-6 pt-3">
 								<StatusButton
 									className="w-full"
-									status={isPending ? 'pending' : actionData?.status ?? 'idle'}
+									status={isPending ? 'pending' : form.status ?? 'idle'}
 									type="submit"
 									disabled={isPending}
 								>

--- a/app/routes/_auth+/reset-password.tsx
+++ b/app/routes/_auth+/reset-password.tsx
@@ -1,5 +1,5 @@
-import { conform, useForm } from '@conform-to/react'
-import { getFieldsetConstraint, parse } from '@conform-to/zod'
+import { getFormProps, getInputProps, useForm } from '@conform-to/react'
+import { getZodConstraint, parseWithZod } from '@conform-to/zod'
 import { invariant } from '@epic-web/invariant'
 import {
 	json,
@@ -22,7 +22,10 @@ import { type VerifyFunctionArgs } from './verify.tsx'
 const resetPasswordUsernameSessionKey = 'resetPasswordUsername'
 
 export async function handleVerification({ submission }: VerifyFunctionArgs) {
-	invariant(submission.value, 'submission.value should be defined by now')
+	invariant(
+		submission.status === 'success',
+		'Submission should be successful by now',
+	)
 	const target = submission.value.target
 	const user = await prisma.user.findFirst({
 		where: { OR: [{ email: target }, { username: target }] },
@@ -31,8 +34,14 @@ export async function handleVerification({ submission }: VerifyFunctionArgs) {
 	// we don't want to say the user is not found if the email is not found
 	// because that would allow an attacker to check if an email is registered
 	if (!user) {
-		submission.error.code = ['Invalid code']
-		return json({ status: 'error', submission } as const, { status: 400 })
+		return json(
+			{
+				result: submission.reply({ fieldErrors: { code: ['Invalid code'] } }),
+			},
+			{
+				status: 400,
+			},
+		)
 	}
 
 	const verifySession = await verifySessionStorage.getSession()
@@ -68,14 +77,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export async function action({ request }: ActionFunctionArgs) {
 	const resetPasswordUsername = await requireResetPasswordUsername(request)
 	const formData = await request.formData()
-	const submission = parse(formData, {
+	const submission = parseWithZod(formData, {
 		schema: ResetPasswordSchema,
 	})
-	if (submission.intent !== 'submit') {
-		return json({ status: 'idle', submission } as const)
-	}
-	if (!submission.value?.password) {
-		return json({ status: 'error', submission } as const, { status: 400 })
+	if (submission.status !== 'success') {
+		return json(
+			{ result: submission.reply() },
+			{
+				status: submission.status === 'error' ? 400 : 200,
+			},
+		)
 	}
 	const { password } = submission.value
 
@@ -99,10 +110,10 @@ export default function ResetPasswordPage() {
 
 	const [form, fields] = useForm({
 		id: 'reset-password',
-		constraint: getFieldsetConstraint(ResetPasswordSchema),
-		lastSubmission: actionData?.submission,
+		constraint: getZodConstraint(ResetPasswordSchema),
+		lastResult: actionData?.result,
 		onValidate({ formData }) {
-			return parse(formData, { schema: ResetPasswordSchema })
+			return parseWithZod(formData, { schema: ResetPasswordSchema })
 		},
 		shouldRevalidate: 'onBlur',
 	})
@@ -116,14 +127,14 @@ export default function ResetPasswordPage() {
 				</p>
 			</div>
 			<div className="mx-auto mt-16 min-w-full max-w-sm sm:min-w-[368px]">
-				<Form method="POST" {...form.props}>
+				<Form method="POST" {...getFormProps(form)}>
 					<Field
 						labelProps={{
 							htmlFor: fields.password.id,
 							children: 'New Password',
 						}}
 						inputProps={{
-							...conform.input(fields.password, { type: 'password' }),
+							...getInputProps(fields.password, { type: 'password' }),
 							autoComplete: 'new-password',
 							autoFocus: true,
 						}}
@@ -135,7 +146,7 @@ export default function ResetPasswordPage() {
 							children: 'Confirm Password',
 						}}
 						inputProps={{
-							...conform.input(fields.confirmPassword, { type: 'password' }),
+							...getInputProps(fields.confirmPassword, { type: 'password' }),
 							autoComplete: 'new-password',
 						}}
 						errors={fields.confirmPassword.errors}
@@ -145,7 +156,7 @@ export default function ResetPasswordPage() {
 
 					<StatusButton
 						className="w-full"
-						status={isPending ? 'pending' : actionData?.status ?? 'idle'}
+						status={isPending ? 'pending' : form.status ?? 'idle'}
 						type="submit"
 						disabled={isPending}
 					>

--- a/app/routes/_auth+/signup.tsx
+++ b/app/routes/_auth+/signup.tsx
@@ -1,5 +1,5 @@
-import { conform, useForm } from '@conform-to/react'
-import { getFieldsetConstraint, parse } from '@conform-to/zod'
+import { getFormProps, getInputProps, useForm } from '@conform-to/react'
+import { getZodConstraint, parseWithZod } from '@conform-to/zod'
 import * as E from '@react-email/components'
 import {
 	json,
@@ -33,7 +33,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 	checkHoneypot(formData)
 
-	const submission = await parse(formData, {
+	const submission = await parseWithZod(formData, {
 		schema: SignupSchema.superRefine(async (data, ctx) => {
 			const existingUser = await prisma.user.findUnique({
 				where: { email: data.email },
@@ -50,11 +50,13 @@ export async function action({ request }: ActionFunctionArgs) {
 		}),
 		async: true,
 	})
-	if (submission.intent !== 'submit') {
-		return json({ status: 'idle', submission } as const)
-	}
-	if (!submission.value) {
-		return json({ status: 'error', submission } as const, { status: 400 })
+	if (submission.status !== 'success') {
+		return json(
+			{ result: submission.reply() },
+			{
+				status: submission.status === 'error' ? 400 : 200,
+			},
+		)
 	}
 	const { email } = submission.value
 	const { verifyUrl, redirectTo, otp } = await prepareVerification({
@@ -73,8 +75,14 @@ export async function action({ request }: ActionFunctionArgs) {
 	if (response.status === 'success') {
 		return redirect(redirectTo.toString())
 	} else {
-		submission.error[''] = [response.error.message]
-		return json({ status: 'error', submission } as const, { status: 500 })
+		return json(
+			{
+				result: submission.reply({ formErrors: [response.error.message] }),
+			},
+			{
+				status: 500,
+			},
+		)
 	}
 }
 
@@ -117,10 +125,10 @@ export default function SignupRoute() {
 
 	const [form, fields] = useForm({
 		id: 'signup-form',
-		constraint: getFieldsetConstraint(SignupSchema),
-		lastSubmission: actionData?.submission,
+		constraint: getZodConstraint(SignupSchema),
+		lastResult: actionData?.result,
 		onValidate({ formData }) {
-			const result = parse(formData, { schema: SignupSchema })
+			const result = parseWithZod(formData, { schema: SignupSchema })
 			return result
 		},
 		shouldRevalidate: 'onBlur',
@@ -135,7 +143,7 @@ export default function SignupRoute() {
 				</p>
 			</div>
 			<div className="mx-auto mt-16 min-w-full max-w-sm sm:min-w-[368px]">
-				<Form method="POST" {...form.props}>
+				<Form method="POST" {...getFormProps(form)}>
 					<HoneypotInputs />
 					<Field
 						labelProps={{
@@ -143,7 +151,7 @@ export default function SignupRoute() {
 							children: 'Email',
 						}}
 						inputProps={{
-							...conform.input(fields.email),
+							...getInputProps(fields.email, { type: 'email' }),
 							autoFocus: true,
 							autoComplete: 'email',
 						}}
@@ -152,7 +160,7 @@ export default function SignupRoute() {
 					<ErrorList errors={form.errors} id={form.errorId} />
 					<StatusButton
 						className="w-full"
-						status={isPending ? 'pending' : actionData?.status ?? 'idle'}
+						status={isPending ? 'pending' : form.status ?? 'idle'}
 						type="submit"
 						disabled={isPending}
 					>

--- a/app/routes/settings+/profile.change-email.tsx
+++ b/app/routes/settings+/profile.change-email.tsx
@@ -1,5 +1,5 @@
-import { conform, useForm } from '@conform-to/react'
-import { getFieldsetConstraint, parse } from '@conform-to/zod'
+import { getFormProps, getInputProps, useForm } from '@conform-to/react'
+import { getZodConstraint, parseWithZod } from '@conform-to/zod'
 import { invariant } from '@epic-web/invariant'
 import { type SEOHandle } from '@nasa-gcn/remix-seo'
 import * as E from '@react-email/components'
@@ -40,17 +40,26 @@ export async function handleVerification({
 	submission,
 }: VerifyFunctionArgs) {
 	await requireRecentVerification(request)
-	invariant(submission.value, 'submission.value should be defined by now')
+	invariant(
+		submission.status === 'success',
+		'Submission should be successful by now',
+	)
 
 	const verifySession = await verifySessionStorage.getSession(
 		request.headers.get('cookie'),
 	)
 	const newEmail = verifySession.get(newEmailAddressSessionKey)
 	if (!newEmail) {
-		submission.error[''] = [
-			'You must submit the code on the same device that requested the email change.',
-		]
-		return json({ status: 'error', submission } as const, { status: 400 })
+		return json(
+			{
+				result: submission.reply({
+					formErrors: [
+						'You must submit the code on the same device that requested the email change.',
+					],
+				}),
+			},
+			{ status: 400 },
+		)
 	}
 	const preUpdateUser = await prisma.user.findFirstOrThrow({
 		select: { email: true },
@@ -104,7 +113,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export async function action({ request }: ActionFunctionArgs) {
 	const userId = await requireUserId(request)
 	const formData = await request.formData()
-	const submission = await parse(formData, {
+	const submission = await parseWithZod(formData, {
 		schema: ChangeEmailSchema.superRefine(async (data, ctx) => {
 			const existingUser = await prisma.user.findUnique({
 				where: { email: data.email },
@@ -120,11 +129,13 @@ export async function action({ request }: ActionFunctionArgs) {
 		async: true,
 	})
 
-	if (submission.intent !== 'submit') {
-		return json({ status: 'idle', submission } as const)
-	}
-	if (!submission.value) {
-		return json({ status: 'error', submission } as const, { status: 400 })
+	if (submission.status !== 'success') {
+		return json(
+			{ result: submission.reply() },
+			{
+				status: submission.status === 'error' ? 400 : 200,
+			},
+		)
 	}
 	const { otp, redirectTo, verifyUrl } = await prepareVerification({
 		period: 10 * 60,
@@ -148,8 +159,14 @@ export async function action({ request }: ActionFunctionArgs) {
 			},
 		})
 	} else {
-		submission.error[''] = [response.error.message]
-		return json({ status: 'error', submission } as const, { status: 500 })
+		return json(
+			{
+				result: submission.reply({ formErrors: [response.error.message] }),
+			},
+			{
+				status: 500,
+			},
+		)
 	}
 }
 
@@ -214,10 +231,10 @@ export default function ChangeEmailIndex() {
 
 	const [form, fields] = useForm({
 		id: 'change-email-form',
-		constraint: getFieldsetConstraint(ChangeEmailSchema),
-		lastSubmission: actionData?.submission,
+		constraint: getZodConstraint(ChangeEmailSchema),
+		lastResult: actionData?.result,
 		onValidate({ formData }) {
-			return parse(formData, { schema: ChangeEmailSchema })
+			return parseWithZod(formData, { schema: ChangeEmailSchema })
 		},
 	})
 
@@ -230,11 +247,11 @@ export default function ChangeEmailIndex() {
 				An email notice will also be sent to your old address {data.user.email}.
 			</p>
 			<div className="mx-auto mt-5 max-w-sm">
-				<Form method="POST" {...form.props}>
+				<Form method="POST" {...getFormProps(form)}>
 					<Field
 						labelProps={{ children: 'New Email' }}
 						inputProps={{
-							...conform.input(fields.email),
+							...getInputProps(fields.email, { type: 'email' }),
 							autoComplete: 'email',
 						}}
 						errors={fields.email.errors}
@@ -242,7 +259,7 @@ export default function ChangeEmailIndex() {
 					<ErrorList id={form.errorId} errors={form.errors} />
 					<div>
 						<StatusButton
-							status={isPending ? 'pending' : actionData?.status ?? 'idle'}
+							status={isPending ? 'pending' : form.status ?? 'idle'}
 						>
 							Send Confirmation
 						</StatusButton>

--- a/app/routes/settings+/profile.photo.tsx
+++ b/app/routes/settings+/profile.photo.tsx
@@ -1,5 +1,5 @@
-import { conform, useForm } from '@conform-to/react'
-import { getFieldsetConstraint, parse } from '@conform-to/zod'
+import { getFormProps, getInputProps, useForm } from '@conform-to/react'
+import { getZodConstraint, parseWithZod } from '@conform-to/zod'
 import { invariantResponse } from '@epic-web/invariant'
 import { type SEOHandle } from '@nasa-gcn/remix-seo'
 import {
@@ -50,7 +50,10 @@ const NewImageSchema = z.object({
 		.refine(file => file.size <= MAX_SIZE, 'Image size must be less than 3MB'),
 })
 
-const PhotoFormSchema = z.union([DeleteImageSchema, NewImageSchema])
+const PhotoFormSchema = z.discriminatedUnion('intent', [
+	DeleteImageSchema,
+	NewImageSchema,
+])
 
 export async function loader({ request }: LoaderFunctionArgs) {
 	const userId = await requireUserId(request)
@@ -74,7 +77,7 @@ export async function action({ request }: ActionFunctionArgs) {
 		unstable_createMemoryUploadHandler({ maxPartSize: MAX_SIZE }),
 	)
 
-	const submission = await parse(formData, {
+	const submission = await parseWithZod(formData, {
 		schema: PhotoFormSchema.transform(async data => {
 			if (data.intent === 'delete') return { intent: 'delete' }
 			if (data.photoFile.size <= 0) return z.NEVER
@@ -89,11 +92,13 @@ export async function action({ request }: ActionFunctionArgs) {
 		async: true,
 	})
 
-	if (submission.intent !== 'submit') {
-		return json({ status: 'idle', submission } as const)
-	}
-	if (!submission.value) {
-		return json({ status: 'error', submission } as const, { status: 400 })
+	if (submission.status !== 'success') {
+		return json(
+			{ result: submission.reply() },
+			{
+				status: submission.status === 'error' ? 400 : 200,
+			},
+		)
 	}
 
 	const { image, intent } = submission.value
@@ -124,22 +129,17 @@ export default function PhotoRoute() {
 
 	const [form, fields] = useForm({
 		id: 'profile-photo',
-		constraint: getFieldsetConstraint(PhotoFormSchema),
-		lastSubmission: actionData?.submission,
+		constraint: getZodConstraint(PhotoFormSchema),
+		lastResult: actionData?.result,
 		onValidate({ formData }) {
-			// otherwise, the best error zod gives us is "Invalid input" which is not
-			// enough
-			if (formData.get('intent') === 'delete') {
-				return parse(formData, { schema: DeleteImageSchema })
-			}
-			return parse(formData, { schema: NewImageSchema })
+			return parseWithZod(formData, { schema: PhotoFormSchema })
 		},
 		shouldRevalidate: 'onBlur',
 	})
 
 	const isPending = useIsPending()
 	const pendingIntent = isPending ? navigation.formData?.get('intent') : null
-	const lastSubmissionIntent = actionData?.submission.value?.intent
+	const lastSubmissionIntent = fields.intent.value
 
 	const [newImageSrc, setNewImageSrc] = useState<string | null>(null)
 
@@ -150,7 +150,7 @@ export default function PhotoRoute() {
 				encType="multipart/form-data"
 				className="flex flex-col items-center justify-center gap-10"
 				onReset={() => setNewImageSrc(null)}
-				{...form.props}
+				{...getFormProps(form)}
 			>
 				<img
 					src={
@@ -168,7 +168,7 @@ export default function PhotoRoute() {
 						an image has been selected). Progressive enhancement FTW!
 					*/}
 					<input
-						{...conform.input(fields.photoFile, { type: 'file' })}
+						{...getInputProps(fields.photoFile, { type: 'file' })}
 						accept="image/*"
 						className="peer sr-only"
 						required
@@ -201,16 +201,16 @@ export default function PhotoRoute() {
 							pendingIntent === 'submit'
 								? 'pending'
 								: lastSubmissionIntent === 'submit'
-								  ? actionData?.status ?? 'idle'
-								  : 'idle'
+									? form.status ?? 'idle'
+									: 'idle'
 						}
 					>
 						Save Photo
 					</StatusButton>
 					<Button
-						type="reset"
 						variant="destructive"
 						className="peer-invalid:hidden"
+						{...form.reset.getButtonProps()}
 					>
 						<Icon name="trash">Reset</Icon>
 					</Button>
@@ -227,8 +227,8 @@ export default function PhotoRoute() {
 								pendingIntent === 'delete'
 									? 'pending'
 									: lastSubmissionIntent === 'delete'
-									  ? actionData?.status ?? 'idle'
-									  : 'idle'
+										? form.status ?? 'idle'
+										: 'idle'
 							}
 						>
 							<Icon name="trash">

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
       "name": "epic-stack-template",
       "license": "MIT",
       "dependencies": {
-        "@conform-to/react": "1.0.0-rc.0",
-        "@conform-to/zod": "1.0.0-rc.0",
+        "@conform-to/react": "^1.0.0",
+        "@conform-to/zod": "^1.0.0",
         "@epic-web/cachified": "^4.0.0",
         "@epic-web/client-hints": "^1.2.2",
         "@epic-web/invariant": "^1.0.0",
@@ -999,27 +999,27 @@
       }
     },
     "node_modules/@conform-to/dom": {
-      "version": "1.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@conform-to/dom/-/dom-1.0.0-rc.0.tgz",
-      "integrity": "sha512-SMs029c+BQuaVt/lin2f8RAL+cwox48EPo0cUMkzz0Oc5rS+GY4scSihS8f1mEBslblvzwzNm0xkiF1WjbDT8g=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@conform-to/dom/-/dom-1.0.0.tgz",
+      "integrity": "sha512-KG0Ee2G9BcFLdqtpcexdht48QNM2F9ddAyJFSHNG4V3e2QOmVEAM7M6R/iWWykpTVQljWmKd2J7U4ep/7/XRrA=="
     },
     "node_modules/@conform-to/react": {
-      "version": "1.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@conform-to/react/-/react-1.0.0-rc.0.tgz",
-      "integrity": "sha512-a975XaxVvO+K3eSjEcnJmb9GvAaAB3DbP3iyfhuOT8ItX0x4GB9KGYO21VBR+c3vce3AJGbBLQDrc7MBw6DZvw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@conform-to/react/-/react-1.0.0.tgz",
+      "integrity": "sha512-TlMMmNDhYJhKJP9EOyV2RbUEqjwR68GTO1KaO3LOI4WeVLx7aZ78k73qIuFMRjjZgsWOL4edD1CZtkKBRztmqw==",
       "dependencies": {
-        "@conform-to/dom": "1.0.0-rc.0"
+        "@conform-to/dom": "1.0.0"
       },
       "peerDependencies": {
         "react": ">=18"
       }
     },
     "node_modules/@conform-to/zod": {
-      "version": "1.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@conform-to/zod/-/zod-1.0.0-rc.0.tgz",
-      "integrity": "sha512-eA7mTmdYO2vDPGLxeW57wVJ6B+6LzF3nxz9bYhuVHjEBcvosOLmoy0pnGg3esACjCpaUFPsHtwSLhThzWstLzw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@conform-to/zod/-/zod-1.0.0.tgz",
+      "integrity": "sha512-oWOfqEpCRZpOY7mxJe73oluy6Fvjbw8tYhXfDqZqFb0ePf+bFkF7g1Wzfkgz76LvWJHb0PNykn+o5f423aqb+w==",
       "dependencies": {
-        "@conform-to/dom": "1.0.0-rc.0"
+        "@conform-to/dom": "1.0.0"
       },
       "peerDependencies": {
         "zod": "^3.21.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
       "name": "epic-stack-template",
       "license": "MIT",
       "dependencies": {
-        "@conform-to/react": "^0.9.1",
-        "@conform-to/zod": "^0.9.1",
+        "@conform-to/react": "1.0.0-rc.0",
+        "@conform-to/zod": "1.0.0-rc.0",
         "@epic-web/cachified": "^4.0.0",
         "@epic-web/client-hints": "^1.2.2",
         "@epic-web/invariant": "^1.0.0",
@@ -999,27 +999,29 @@
       }
     },
     "node_modules/@conform-to/dom": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@conform-to/dom/-/dom-0.9.1.tgz",
-      "integrity": "sha512-+T6QgpLDPZ29j4y5nWW61WMe8qj0cQBymyzbi5sq1f3CcBO3wBbR0VPI7mbm+rLoErHWM3ghhdNlIkw0UPoLLA=="
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@conform-to/dom/-/dom-1.0.0-rc.0.tgz",
+      "integrity": "sha512-SMs029c+BQuaVt/lin2f8RAL+cwox48EPo0cUMkzz0Oc5rS+GY4scSihS8f1mEBslblvzwzNm0xkiF1WjbDT8g=="
     },
     "node_modules/@conform-to/react": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@conform-to/react/-/react-0.9.1.tgz",
-      "integrity": "sha512-SibYHk86IFh60LRPk4aJHJOgyLTgb3JYphKvG4vcemyuntdOwncd5YM/GDoccVzeCTmJi4Os/fDtOOAaDcSa9w==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@conform-to/react/-/react-1.0.0-rc.0.tgz",
+      "integrity": "sha512-a975XaxVvO+K3eSjEcnJmb9GvAaAB3DbP3iyfhuOT8ItX0x4GB9KGYO21VBR+c3vce3AJGbBLQDrc7MBw6DZvw==",
       "dependencies": {
-        "@conform-to/dom": "0.9.1"
+        "@conform-to/dom": "1.0.0-rc.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18"
       }
     },
     "node_modules/@conform-to/zod": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@conform-to/zod/-/zod-0.9.1.tgz",
-      "integrity": "sha512-4hWBGzRpSd4RrlBFRXjS6QQ2MWFpMZDbDwz8H/xiq38Xl5yaL1RSZMhOJ4pmsmy8CIKghs78qvaD8ltTFlrNvQ==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@conform-to/zod/-/zod-1.0.0-rc.0.tgz",
+      "integrity": "sha512-eA7mTmdYO2vDPGLxeW57wVJ6B+6LzF3nxz9bYhuVHjEBcvosOLmoy0pnGg3esACjCpaUFPsHtwSLhThzWstLzw==",
+      "dependencies": {
+        "@conform-to/dom": "1.0.0-rc.0"
+      },
       "peerDependencies": {
-        "@conform-to/dom": "0.9.1",
         "zod": "^3.21.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "/server-build"
   ],
   "dependencies": {
-    "@conform-to/react": "^0.9.1",
-    "@conform-to/zod": "^0.9.1",
+    "@conform-to/react": "1.0.0-rc.0",
+    "@conform-to/zod": "1.0.0-rc.0",
     "@epic-web/cachified": "^4.0.0",
     "@epic-web/client-hints": "^1.2.2",
     "@epic-web/invariant": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "/server-build"
   ],
   "dependencies": {
-    "@conform-to/react": "1.0.0-rc.0",
-    "@conform-to/zod": "1.0.0-rc.0",
+    "@conform-to/react": "^1.0.0",
+    "@conform-to/zod": "^1.0.0",
     "@epic-web/cachified": "^4.0.0",
     "@epic-web/client-hints": "^1.2.2",
     "@epic-web/invariant": "^1.0.0",


### PR DESCRIPTION
> This is a draft based on v1.0.0-rc.0 and require no action until v1 is released

Here you can find a summary of all the changes required to upgrade to Conform v1.

- All the conform helpers are renamed, e.g. `conform.input` -> `getInputProps`
- Both `parse` and `getFieldsetConstraint` are renamed to `parseWithZod` and `getZodConstraint`
- Setting up the form using the `getFormProps` helper instead of `form.props` which is no longer available
- Control the submission flow using `submission.status` and manipulate it using the new `submission.reply()` API
- Removed the status from the server response as it is now covered with the submission API and is accessible through `form.status`
