### PR TITLE
Use m1 runner to speed up deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   lint:
     name: ⬣ ESLint
-    runs-on: ubuntu-22.04
+    runs-on: macos-14
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
 
   typecheck:
     name: ʦ TypeScript
-    runs-on: ubuntu-22.04
+    runs-on: macos-14
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
@@ -59,7 +59,7 @@ jobs:
 
   vitest:
     name: ⚡ Vitest
-    runs-on: ubuntu-22.04
+    runs-on: macos-14
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
@@ -83,7 +83,7 @@ jobs:
 
   playwright:
     name: 🎭 Playwright
-    runs-on: ubuntu-22.04
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - name: ⬇️ Checkout repo
@@ -138,7 +138,7 @@ jobs:
 
   deploy:
     name: 🚀 Deploy
-    runs-on: ubuntu-22.04
+    runs-on: macos-14
     needs: [lint, typecheck, vitest, playwright]
     # only build/deploy main branch on pushes
     if:


### PR DESCRIPTION
> The new runner executes Actions workflows with a 3 vCPU, 7 GB RAM, and 14 GB of storage VM, which provides the latest Mac hardware Actions has to offer.
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

## Screenshots


### Typecheck 6s -> 4s
![image](https://github.com/epicweb-dev/epic-stack/assets/84349818/9feeb318-2c4e-460f-a53f-d25c697f887f)

### Vitest 7s -> 4s
![image](https://github.com/epicweb-dev/epic-stack/assets/84349818/8b987f2c-3d11-4a82-bbff-a149db3d7161)

### Playwright Install 25s -> 5s

![image](https://github.com/epicweb-dev/epic-stack/assets/84349818/392393fa-d046-4aa2-9b04-a58e9ab9084d)

### Playwright Test 26s -> 21s
![image](https://github.com/epicweb-dev/epic-stack/assets/84349818/06781656-6dea-46ff-a1b0-7a176a911522)

Honestly, the vanilla stack isn't big enough for it to make a notable difference, but it might for more built out apps? Are there any production builds we can check against?

(note: this deploy is a tad slower because of blank npm cache)


