### PR TITLE
feat(wal): reenables wal mode for litefs after resolution of issue

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -16,6 +16,7 @@ destination = "/data"
 release_command = "node ./other/sentry-create-release"
 
 [env]
+# For WAL support: https://github.com/prisma/prisma-engines/issues/4675#issuecomment-1914383246
 PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK = "1"
 
 [[services]]

--- a/fly.toml
+++ b/fly.toml
@@ -15,6 +15,9 @@ destination = "/data"
 [deploy]
 release_command = "node ./other/sentry-create-release"
 
+[env]
+PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK = "1"
+
 [[services]]
 internal_port = 8080
 processes = [ "app" ]

--- a/fly.toml
+++ b/fly.toml
@@ -15,10 +15,6 @@ destination = "/data"
 [deploy]
 release_command = "node ./other/sentry-create-release"
 
-[env]
-# For WAL support: https://github.com/prisma/prisma-engines/issues/4675#issuecomment-1914383246
-PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK = "1"
-
 [[services]]
 internal_port = 8080
 processes = [ "app" ]

--- a/other/Dockerfile
+++ b/other/Dockerfile
@@ -52,6 +52,8 @@ ENV CACHE_DATABASE_PATH="$LITEFS_DIR/$CACHE_DATABASE_FILENAME"
 ENV INTERNAL_PORT="8080"
 ENV PORT="8081"
 ENV NODE_ENV="production"
+# For WAL support: https://github.com/prisma/prisma-engines/issues/4675#issuecomment-1914383246
+ENV PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK = "1"
 
 # add shortcut for connecting to database CLI
 RUN echo "#!/bin/sh\nset -x\nsqlite3 \$DATABASE_URL" > /usr/local/bin/database-cli && chmod +x /usr/local/bin/database-cli

--- a/other/Dockerfile
+++ b/other/Dockerfile
@@ -71,7 +71,7 @@ COPY --from=build /myapp/prisma /myapp/prisma
 COPY --from=build /myapp/app/components/ui/icons /myapp/app/components/ui/icons
 
 # prepare for litefs
-COPY --from=flyio/litefs:0.5.8 /usr/local/bin/litefs /usr/local/bin/litefs
+COPY --from=flyio/litefs:0.5.11 /usr/local/bin/litefs /usr/local/bin/litefs
 ADD other/litefs.yml /etc/litefs.yml
 RUN mkdir -p /data ${LITEFS_DIR}
 

--- a/other/litefs.yml
+++ b/other/litefs.yml
@@ -34,8 +34,7 @@ exec:
   - cmd: npx prisma migrate deploy
     if-candidate: true
 
-  # re-enable these when this is fixed: https://github.com/superfly/litefs/issues/425
-  # # Set the journal mode for the database to WAL. This reduces concurrency deadlock issues
+  # Set the journal mode for the database to WAL. This reduces concurrency deadlock issues
   - cmd: sqlite3 $DATABASE_PATH "PRAGMA journal_mode = WAL;"
     if-candidate: true
 

--- a/other/litefs.yml
+++ b/other/litefs.yml
@@ -38,7 +38,7 @@ exec:
   - cmd: sqlite3 $DATABASE_PATH "PRAGMA journal_mode = WAL;"
     if-candidate: true
 
-  # # Set the journal mode for the cache to WAL. This reduces concurrency deadlock issues
+  # Set the journal mode for the cache to WAL. This reduces concurrency deadlock issues
   - cmd: sqlite3 $CACHE_DATABASE_PATH "PRAGMA journal_mode = WAL;"
     if-candidate: true
 

--- a/other/litefs.yml
+++ b/other/litefs.yml
@@ -36,11 +36,11 @@ exec:
 
   # re-enable these when this is fixed: https://github.com/superfly/litefs/issues/425
   # # Set the journal mode for the database to WAL. This reduces concurrency deadlock issues
-  # - cmd: sqlite3 $DATABASE_PATH "PRAGMA journal_mode = WAL;"
-  #   if-candidate: true
+  - cmd: sqlite3 $DATABASE_PATH "PRAGMA journal_mode = WAL;"
+    if-candidate: true
 
   # # Set the journal mode for the cache to WAL. This reduces concurrency deadlock issues
-  # - cmd: sqlite3 $CACHE_DATABASE_PATH "PRAGMA journal_mode = WAL;"
-  #   if-candidate: true
+  - cmd: sqlite3 $CACHE_DATABASE_PATH "PRAGMA journal_mode = WAL;"
+    if-candidate: true
 
   - cmd: npm start


### PR DESCRIPTION
It looks like the [issue that were preventing the Epic Stack from using WAL](https://github.com/superfly/litefs/issues/425) mode has been resolved. This PR updates the version of LiteFS used to [0.5.11](https://github.com/superfly/litefs/releases) and un-comments the lines that enable WAL mode.

Enables WAL mode for the local db [per this comment.](https://github.com/prisma/prisma/issues/3303#issuecomment-1565192313) Not sure if this is correct. 👀

I started looking into this because the call to `prisma.verification.upsert` in the function `prepareVerification` started failing for me locally with the following error: `Invalid 'prisma.verification.upsert()' invocation: internal error: entered unreachable code`. I started investigating WAL mode because of [this GH issue](https://github.com/prisma/prisma/issues/10403).

## Test Plan
I believe the existing tests cover this change.

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

No visual changes
