### PR TITLE
Demo for issue #635

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -196,7 +196,7 @@ app.use((req, res, next) => {
 
 async function getBuild() {
 	const build = viteDevServer
-		? viteDevServer.ssrLoadModule('virtual:remix/server-build')
+		? () => viteDevServer.ssrLoadModule('virtual:remix/server-build')
 		: // @ts-ignore this should exist before running the server
 			// but it may not exist just yet.
 			await import('#build/server/index.js')
@@ -213,7 +213,7 @@ app.all(
 		}),
 		mode: MODE,
 		// @sentry/remix needs to be updated to handle the function signature
-		build: MODE === 'production' ? await getBuild() : getBuild,
+		build: await getBuild(),
 	}),
 )
 


### PR DESCRIPTION
#635 

however, I have realized my error.
I was follow the epic stack in my remix app and was not ready for Sentry. Therefore the comment about it in `server/index.ts` made me this I could get rid of the NODE_ENV check. Therefore, I was left with just the `await getBuild()` call. However, because I was calling `getBuild` now in development the `viteDevServer.ssrLoadModule` part needed to be wrapped in a function like the remix/website example

To summarize. If you try this branch out and remove the wrapper function around `viteDevServer.ssrLoadModule` you will see that the app starts but updates inside a loader are not reflected. Which is where I thought to help

Please let me know if you would like more. Thank you for the Epic Stack and all your work

<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
