### PR TITLE
eslintrc typings

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,7 +2,7 @@ const vitestFiles = ['app/**/__tests__/**/*', 'app/**/*.{spec,test}.*']
 const testFiles = ['**/tests/**', ...vitestFiles]
 const appFiles = ['app/**']
 
-/** @type {import('@types/eslint').Linter.BaseConfig} */
+/** @type {import('@types/eslint').Linter.Config} */
 module.exports = {
 	extends: [
 		'@remix-run/eslint-config',


### PR DESCRIPTION
eslintrc was typed with BaseConfig instead of Config

this fixes https://github.com/epicweb-dev/epic-stack/issues/647
