### PR TITLE
Do not render the errors list container if there are no errors

### DIFF
--- a/app/components/forms.tsx
+++ b/app/components/forms.tsx
@@ -50,9 +50,11 @@ export function Field({
 				aria-describedby={errorId}
 				{...inputProps}
 			/>
-			<div className="min-h-[32px] px-4 pb-3 pt-1">
-				{errorId ? <ErrorList id={errorId} errors={errors} /> : null}
-			</div>
+			{errorId ? (
+				<div className="min-h-[32px] px-4 pb-3 pt-1">
+					<ErrorList id={errorId} errors={errors} />
+				</div>
+			) : null}
 		</div>
 	)
 }
@@ -80,9 +82,11 @@ export function TextareaField({
 				aria-describedby={errorId}
 				{...textareaProps}
 			/>
-			<div className="min-h-[32px] px-4 pb-3 pt-1">
-				{errorId ? <ErrorList id={errorId} errors={errors} /> : null}
-			</div>
+			{errorId ? (
+				<div className="min-h-[32px] px-4 pb-3 pt-1">
+					<ErrorList id={errorId} errors={errors} />
+				</div>
+			) : null}
 		</div>
 	)
 }


### PR DESCRIPTION
This container, when empty, creates extra space below the field for no reason.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
