### PR TITLE
Remove manual typedef for tailwindcss-animate

### DIFF
--- a/types/deps.d.ts
+++ b/types/deps.d.ts
@@ -1,9 +1,6 @@
 // This module should contain type definitions for modules which do not have
 // their own type definitions and are not available on DefinitelyTyped.
 
-declare module 'tailwindcss-animate' {
-	declare const _default: {
-		handler: () => void
-	}
-	export = _default
-}
+// declare module 'some-untyped-pkg' {
+// 	export function foo(): void;
+// }


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
Types available as of `tailwindcss-animate@1.0.7` 

[relevant upstream commit](https://github.com/jamiebuilds/tailwindcss-animate/commit/8d72e105c5f0f3f0ec5deac78a5d552710b60501)