### PR TITLE
fix sentry cors issues

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -24,7 +24,7 @@ be done in the `server/index.ts` file.
 			directives: {
 				'connect-src': [
 					MODE === 'development' ? 'ws:' : null,
-					process.env.SENTRY_DSN ? '*.ingest.sentry.io' : null,
+					process.env.SENTRY_DSN ? '*.sentry.io' : null,
 					"'self'",
 				].filter(Boolean),
 				'font-src': ["'self'"],

--- a/server/index.ts
+++ b/server/index.ts
@@ -116,7 +116,7 @@ app.use(
 			directives: {
 				'connect-src': [
 					MODE === 'development' ? 'ws:' : null,
-					process.env.SENTRY_DSN ? '*.ingest.sentry.io' : null,
+					process.env.SENTRY_DSN ? '*.sentry.io' : null,
 					"'self'",
 				].filter(Boolean),
 				'font-src': ["'self'"],


### PR DESCRIPTION
sentry changed its url from *.ingest.sentry.io to *.ingest.[LOCATION].sentry.io

which results in cors errors

```
[Report Only] Refused to connect to '.......' because it violates the following Content Security Policy directive: "connect-src *.ingest.sentry.io 'self'".
```