### PR TITLE
Port unavailable handling

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -16,6 +16,7 @@ installGlobals()
 
 const MODE = process.env.NODE_ENV ?? 'development'
 const IS_PROD = MODE === 'production'
+const IS_DEV = MODE === "development"
 
 const createRequestHandler = IS_PROD
 	? Sentry.wrapExpressCreateRequestHandler(_createRequestHandler)
@@ -221,7 +222,7 @@ const portToUse = await getPort({
 	port: portNumbers(desiredPort, desiredPort + 100),
 })
 const portAvailable = desiredPort === portToUse
-if (MODE !== 'development' && !portAvailable) {
+if (!portAvailable && !IS_DEV) {
 	console.log(`⚠️ Port ${desiredPort} is not available.`)
 	process.exit(1)
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -220,28 +220,29 @@ const desiredPort = Number(process.env.PORT || 3000)
 const portToUse = await getPort({
 	port: portNumbers(desiredPort, desiredPort + 100),
 })
+const portAvailable = desiredPort === portToUse
+if (MODE !== 'development' && !portAvailable) {
+	console.log(`⚠️ Port ${desiredPort} is not available.`)
+	process.exit(1)
+}
 
 const server = app.listen(portToUse, () => {
-	const addy = server.address()
-	const portActuallyUsed =
-		addy === null || typeof addy === 'string' ? 0 : addy.port
-
-	if (portActuallyUsed !== desiredPort) {
+	if (!portAvailable) {
 		console.warn(
 			chalk.yellow(
-				`⚠️  Port ${desiredPort} is not available, using ${portActuallyUsed} instead.`,
+				`⚠️  Port ${desiredPort} is not available, using ${portToUse} instead.`,
 			),
 		)
 	}
 	console.log(`🚀  We have liftoff!`)
-	const localUrl = `http://localhost:${portActuallyUsed}`
+	const localUrl = `http://localhost:${portToUse}`
 	let lanUrl: string | null = null
 	const localIp = ipAddress() ?? 'Unknown'
 	// Check if the address is a private ip
 	// https://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces
 	// https://github.com/facebook/create-react-app/blob/d960b9e38c062584ff6cfb1a70e1512509a966e7/packages/react-dev-utils/WebpackDevServerUtils.js#LL48C9-L54C10
 	if (/^10[.]|^172[.](1[6-9]|2[0-9]|3[0-1])[.]|^192[.]168[.]/.test(localIp)) {
-		lanUrl = `http://${localIp}:${portActuallyUsed}`
+		lanUrl = `http://${localIp}:${portToUse}`
 	}
 
 	console.log(


### PR DESCRIPTION
On staging, production or any other deployed environment, we (dockerd/proxy/balancer) need to know the port the service will be available on ahead of time. So if it is `3000` and this port is taken on the machine, we should not be trying to re-assign. This re-assigning only makes sense during  the development.

The callback passed to Express `app.listen` will not accept an error that we could immediately logged and so we would be able  to terminate the process.

However we can utilize the `portToUse` returned from `getPort` utillity, and if it is not the same as the desired one AND the environment is not `"development"`, we should immediately exit with non zero.

To test out, launch a session and hit `npm run dev`, then launch another one and issue the same command, you will see we've got 3001 assigned as expected. Then run `npm run build` and repeat the same test but this time with `npm run start`. You should see the process terminated with the corresponding message logged out.

I apologize for [this](https://github.com/epicweb-dev/epic-stack/pull/668#discussion_r1536848461) - I mistakenly thought that if we are not handling the port-already-in-use error in the `app.listen` callback, that means the app asked the OS for a new one for us. That's not the case. And this, anyhow, should - I guess - be only dev env behavior.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated N/A
- [ ] Docs updated N/A

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
