### PR TITLE
Update sentry auth scope documentation

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -39,7 +39,7 @@ To generate the auth token, click
 [this](https://sentry.io/orgredirect/settings/:orgslug/developer-settings/new-internal/)
 to create an internal integration (which grants the selected capabilities to the
 recipient, similar to how RBAC works). Give it a name and add the scope for
-`Releases:Admin`. Press Save, find the auth token at the bottom of the page
+`Releases:Admin` and `Organization:Read`. Press Save, find the auth token at the bottom of the page
 under "Tokens", and copy that to secure location (this becomes
 `SENTRY_AUTH_TOKEN`). Then visit the organization settings page and copy that
 organization slug (`SENTRY_ORG`), and the slug name for your project too


### PR DESCRIPTION
I had some issues setting up Sentry for my newly created app. The solution _for me_ boiled down to the fact that I had given my custom integration too limited access scope. According to [this support question](https://forum.sentry.io/t/403-error-adding-commits-to-release/4708) except from `project:releases` (or `Release:Admin`) it also needs `org:read` (or `Organization:Read`). And if I understand the accepted answer in the support question this should apply to everyone.

This PR updates the documentation to properly reflect that requirement.

## Test Plan

_No testing necessary_

## Checklist

- [x] ~~Tests updated~~
- [x] Docs updated

## Screenshots

_No screenshots necessary_
