### PR TITLE
feat: use OTP input from shadcn/ui

### DIFF
--- a/app/components/forms.tsx
+++ b/app/components/forms.tsx
@@ -1,6 +1,13 @@
 import { useInputControl } from '@conform-to/react'
+import { REGEXP_ONLY_DIGITS_AND_CHARS, type OTPInputProps } from 'input-otp'
 import React, { useId } from 'react'
 import { Checkbox, type CheckboxProps } from './ui/checkbox.tsx'
+import {
+	InputOTP,
+	InputOTPGroup,
+	InputOTPSeparator,
+	InputOTPSlot,
+} from './ui/input-otp.tsx'
 import { Input } from './ui/input.tsx'
 import { Label } from './ui/label.tsx'
 import { Textarea } from './ui/textarea.tsx'
@@ -50,6 +57,50 @@ export function Field({
 				aria-describedby={errorId}
 				{...inputProps}
 			/>
+			<div className="min-h-[32px] px-4 pb-3 pt-1">
+				{errorId ? <ErrorList id={errorId} errors={errors} /> : null}
+			</div>
+		</div>
+	)
+}
+
+export function OTPField({
+	labelProps,
+	inputProps,
+	errors,
+	className,
+}: {
+	labelProps: React.LabelHTMLAttributes<HTMLLabelElement>
+	inputProps: Partial<OTPInputProps & { render: never }>
+	errors?: ListOfErrors
+	className?: string
+}) {
+	const fallbackId = useId()
+	const id = inputProps.id ?? fallbackId
+	const errorId = errors?.length ? `${id}-error` : undefined
+	return (
+		<div className={className}>
+			<Label htmlFor={id} {...labelProps} />
+			<InputOTP
+				pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+				maxLength={6}
+				id={id}
+				aria-invalid={errorId ? true : undefined}
+				aria-describedby={errorId}
+				{...inputProps}
+			>
+				<InputOTPGroup>
+					<InputOTPSlot index={0} />
+					<InputOTPSlot index={1} />
+					<InputOTPSlot index={2} />
+				</InputOTPGroup>
+				<InputOTPSeparator />
+				<InputOTPGroup>
+					<InputOTPSlot index={3} />
+					<InputOTPSlot index={4} />
+					<InputOTPSlot index={5} />
+				</InputOTPGroup>
+			</InputOTP>
 			<div className="min-h-[32px] px-4 pb-3 pt-1">
 				{errorId ? <ErrorList id={errorId} errors={errors} /> : null}
 			</div>

--- a/app/components/ui/input-otp.tsx
+++ b/app/components/ui/input-otp.tsx
@@ -1,0 +1,68 @@
+import { OTPInput, OTPInputContext } from 'input-otp'
+import * as React from 'react'
+
+import { cn } from '#app/utils/misc.tsx'
+
+const InputOTP = React.forwardRef<
+	React.ElementRef<typeof OTPInput>,
+	React.ComponentPropsWithoutRef<typeof OTPInput>
+>(({ className, containerClassName, ...props }, ref) => (
+	<OTPInput
+		ref={ref}
+		containerClassName={cn(
+			'flex items-center gap-2 has-[:disabled]:opacity-50',
+			containerClassName,
+		)}
+		className={cn('disabled:cursor-not-allowed', className)}
+		{...props}
+	/>
+))
+InputOTP.displayName = 'InputOTP'
+
+const InputOTPGroup = React.forwardRef<
+	React.ElementRef<'div'>,
+	React.ComponentPropsWithoutRef<'div'>
+>(({ className, ...props }, ref) => (
+	<div ref={ref} className={cn('flex items-center', className)} {...props} />
+))
+InputOTPGroup.displayName = 'InputOTPGroup'
+
+const InputOTPSlot = React.forwardRef<
+	React.ElementRef<'div'>,
+	React.ComponentPropsWithoutRef<'div'> & { index: number }
+>(({ index, className, ...props }, ref) => {
+	const inputOTPContext = React.useContext(OTPInputContext)
+	const { char, hasFakeCaret, isActive } = inputOTPContext.slots[index]
+
+	return (
+		<div
+			ref={ref}
+			className={cn(
+				'relative flex h-10 w-10 items-center justify-center border-y border-r border-input text-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md',
+				isActive && 'z-10 ring-2 ring-ring ring-offset-background',
+				className,
+			)}
+			{...props}
+		>
+			{char}
+			{hasFakeCaret && (
+				<div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+					<div className="h-4 w-px animate-caret-blink bg-foreground duration-1000" />
+				</div>
+			)}
+		</div>
+	)
+})
+InputOTPSlot.displayName = 'InputOTPSlot'
+
+const InputOTPSeparator = React.forwardRef<
+	React.ElementRef<'div'>,
+	React.ComponentPropsWithoutRef<'div'>
+>(({ ...props }, ref) => (
+	<div ref={ref} role="separator" {...props}>
+		-
+	</div>
+))
+InputOTPSeparator.displayName = 'InputOTPSeparator'
+
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator }

--- a/app/routes/_auth+/verify.tsx
+++ b/app/routes/_auth+/verify.tsx
@@ -5,7 +5,7 @@ import { Form, useActionData, useSearchParams } from '@remix-run/react'
 import { HoneypotInputs } from 'remix-utils/honeypot/react'
 import { z } from 'zod'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
-import { ErrorList, Field } from '#app/components/forms.tsx'
+import { ErrorList, OTPField } from '#app/components/forms.tsx'
 import { Spacer } from '#app/components/spacer.tsx'
 import { StatusButton } from '#app/components/ui/status-button.tsx'
 import { checkHoneypot } from '#app/utils/honeypot.server.ts'
@@ -95,17 +95,19 @@ export default function VerifyRoute() {
 				<div className="flex w-full gap-2">
 					<Form method="POST" {...getFormProps(form)} className="flex-1">
 						<HoneypotInputs />
-						<Field
-							labelProps={{
-								htmlFor: fields[codeQueryParam].id,
-								children: 'Code',
-							}}
-							inputProps={{
-								...getInputProps(fields[codeQueryParam], { type: 'text' }),
-								autoComplete: 'one-time-code',
-							}}
-							errors={fields[codeQueryParam].errors}
-						/>
+						<div className="flex items-center justify-center">
+							<OTPField
+								labelProps={{
+									htmlFor: fields[codeQueryParam].id,
+									children: 'Code',
+								}}
+								inputProps={{
+									...getInputProps(fields[codeQueryParam], { type: 'text' }),
+									autoComplete: 'one-time-code',
+								}}
+								errors={fields[codeQueryParam].errors}
+							/>
+						</div>
 						<input
 							{...getInputProps(fields[typeQueryParam], { type: 'hidden' })}
 						/>

--- a/app/routes/settings+/profile.two-factor.verify.tsx
+++ b/app/routes/settings+/profile.two-factor.verify.tsx
@@ -15,7 +15,7 @@ import {
 } from '@remix-run/react'
 import * as QRCode from 'qrcode'
 import { z } from 'zod'
-import { ErrorList, Field } from '#app/components/forms.tsx'
+import { ErrorList, OTPField } from '#app/components/forms.tsx'
 import { Icon } from '#app/components/ui/icon.tsx'
 import { StatusButton } from '#app/components/ui/status-button.tsx'
 import { isCodeValid } from '#app/routes/_auth+/verify.server.ts'
@@ -175,18 +175,20 @@ export default function TwoFactorRoute() {
 				</p>
 				<div className="flex w-full max-w-xs flex-col justify-center gap-4">
 					<Form method="POST" {...getFormProps(form)} className="flex-1">
-						<Field
-							labelProps={{
-								htmlFor: fields.code.id,
-								children: 'Code',
-							}}
-							inputProps={{
-								...getInputProps(fields.code, { type: 'text' }),
-								autoFocus: true,
-								autoComplete: 'one-time-code',
-							}}
-							errors={fields.code.errors}
-						/>
+						<div className="flex items-center justify-center">
+							<OTPField
+								labelProps={{
+									htmlFor: fields.code.id,
+									children: 'Code',
+								}}
+								inputProps={{
+									...getInputProps(fields.code, { type: 'text' }),
+									autoFocus: true,
+									autoComplete: 'one-time-code',
+								}}
+								errors={fields.code.errors}
+							/>
+						</div>
 
 						<div className="min-h-[32px] px-4 pb-3 pt-1">
 							<ErrorList id={form.errorId} errors={form.errors} />

--- a/app/utils/extended-theme.ts
+++ b/app/utils/extended-theme.ts
@@ -90,4 +90,13 @@ export const extendedTheme = {
 		/** 12px size / 16px high / bold */
 		button: ['0.75rem', { lineHeight: '1rem', fontWeight: '700' }],
 	},
+	keyframes: {
+		'caret-blink': {
+			'0%,70%,100%': { opacity: '1' },
+			'20%,50%': { opacity: '0' },
+		},
+	},
+	animation: {
+		'caret-blink': 'caret-blink 1.25s ease-out infinite',
+	},
 } satisfies Config['theme']

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "get-port": "^7.1.0",
         "glob": "^10.3.12",
         "helmet": "^7.1.0",
+        "input-otp": "^1.2.4",
         "intl-parse-accept-language": "^1.0.0",
         "isbot": "^5.1.6",
         "litefs-js": "^1.1.2",
@@ -11626,6 +11627,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
       "dev": true
+    },
+    "node_modules/input-otp": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.2.4.tgz",
+      "integrity": "sha512-md6rhmD+zmMnUh5crQNSQxq3keBRYvE3odbr4Qb9g2NWzQv9azi+t1a3X4TBTbh98fsGHgEEJlzbe1q860uGCA==",
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "get-port": "^7.1.0",
     "glob": "^10.3.12",
     "helmet": "^7.1.0",
+    "input-otp": "^1.2.4",
     "intl-parse-accept-language": "^1.0.0",
     "isbot": "^5.1.6",
     "litefs-js": "^1.1.2",


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
I added shadnc/ui [Input OTP](https://ui.shadcn.com/docs/components/input-otp) component to be consistent with the rest of the app.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->

### Enabling 2FA
https://github.com/epicweb-dev/epic-stack/assets/57627858/5388aab7-9def-41b4-92eb-2532b7d983cf

### Signup

https://github.com/epicweb-dev/epic-stack/assets/57627858/021e8435-889d-4ea1-9aaf-20072c178ffd
