### PR TITLE
Update node to v22 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "vitest": "^1.5.3"
   },
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"


### PR DESCRIPTION
I ran `npx create-epic-app@latest` this morning, then ran `npm run test:e2e:run` as the first thing in my newly generated app. It failed with this error:

```
> test:e2e:run
> cross-env CI=true playwright test

TypeError [ERR_INVALID_ARG_TYPE]: The "parentURL" argument must be of type string or an instance of URL. Received an instance of Object
    at new NodeError (node:internal/errors:405:5)
    at throwIfInvalidParentURL (node:internal/modules/esm/resolve:937:11)
    at Hooks.resolve (node:internal/modules/esm/hooks:241:5)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:337:35)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:220:38)
    at ModuleLoader.import (node:internal/modules/esm/loader:307:34)
    at Hooks.register (node:internal/modules/esm/hooks:138:51)
    at MessagePort.handleMessage (node:internal/modules/esm/worker:168:24)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:807:20)
    at exports.emitMessage (node:internal/per_context/messageport:23:28) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

After some digging and trial-and-error, I found that the problem was that I was running with node 20. The most concerning part is: not even switching to node 22 fixed it. I had to re-run `npx create-epic-app@latest` using node 22 also. Using the version of the app created with node 20 did not work, even if I switched to node 22 afterward.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

