### PR TITLE
fix: ignore inlining small assets for the svg sprite

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,12 @@ export default defineConfig({
 			external: [/node:.*/, 'stream', 'crypto', 'fsevents'],
 		},
 
+		assetsInlineLimit: (source: string) => {
+			if (source.endsWith('sprite.svg')) {
+				return false;
+			}
+		},
+
 		sourcemap: true,
 	},
 	plugins: [


### PR DESCRIPTION
Vite by default will inline small assets to avoid extra requests, this wont work when using sprites. In this case we need to make sure the file is referenced as an URL otherwise the browser will block it.

See:
- https://stackoverflow.com/questions/69076708/getting-unsafe-attempt-to-load-url-dataimage-svgxml-in-safari-using-a-thr

- https://stackoverflow.com/questions/29493965/unsafe-attempt-to-load-url-svg

<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
