### PR TITLE
feat: simplify new app setup by reducing areas that need modification

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -44,6 +44,7 @@ import { EpicToaster } from './components/ui/sonner.tsx'
 import tailwindStyleSheetUrl from './styles/tailwind.css?url'
 import { getUserId, logout } from './utils/auth.server.ts'
 import { ClientHintCheck, getHints, useHints } from './utils/client-hints.tsx'
+import { APP_NAME } from './utils/constants.ts'
 import { prisma } from './utils/db.server.ts'
 import { getEnv } from './utils/env.server.ts'
 import { honeypot } from './utils/honeypot.server.ts'
@@ -80,7 +81,7 @@ export const links: LinksFunction = () => {
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
 	return [
-		{ title: data ? 'Epic Notes' : 'Error | Epic Notes' },
+		{ title: data ? APP_NAME : `Error | ${APP_NAME}` },
 		{ name: 'description', content: `Your own captain's log` },
 	]
 }
@@ -270,14 +271,17 @@ function App() {
 }
 
 function Logo() {
+	const appNameSplit = APP_NAME.toLowerCase().split(' ')
 	return (
 		<Link to="/" className="group grid leading-snug">
 			<span className="font-light transition group-hover:-translate-x-1">
-				epic
+				{appNameSplit[0]}
 			</span>
-			<span className="font-bold transition group-hover:translate-x-1">
-				notes
-			</span>
+			{appNameSplit.length >= 2 ? (
+				<span className="font-bold transition group-hover:translate-x-1">
+					{appNameSplit.slice(1).join(' ')}
+				</span>
+			) : null}
 		</Link>
 	)
 }

--- a/app/routes/_auth+/forgot-password.tsx
+++ b/app/routes/_auth+/forgot-password.tsx
@@ -13,6 +13,7 @@ import { z } from 'zod'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
 import { ErrorList, Field } from '#app/components/forms.tsx'
 import { StatusButton } from '#app/components/ui/status-button.tsx'
+import { APP_NAME } from '#app/utils/constants.js'
 import { prisma } from '#app/utils/db.server.ts'
 import { sendEmail } from '#app/utils/email.server.ts'
 import { checkHoneypot } from '#app/utils/honeypot.server.ts'
@@ -70,7 +71,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 	const response = await sendEmail({
 		to: user.email,
-		subject: `Epic Notes Password Reset`,
+		subject: `${APP_NAME} Password Reset`,
 		react: (
 			<ForgotPasswordEmail onboardingUrl={verifyUrl.toString()} otp={otp} />
 		),
@@ -97,7 +98,7 @@ function ForgotPasswordEmail({
 		<E.Html lang="en" dir="ltr">
 			<E.Container>
 				<h1>
-					<E.Text>Epic Notes Password Reset</E.Text>
+					<E.Text>{APP_NAME} Password Reset</E.Text>
 				</h1>
 				<p>
 					<E.Text>
@@ -114,7 +115,7 @@ function ForgotPasswordEmail({
 }
 
 export const meta: MetaFunction = () => {
-	return [{ title: 'Password Recovery for Epic Notes' }]
+	return [{ title: `Password Recovery for ${APP_NAME}` }]
 }
 
 export default function ForgotPasswordRoute() {

--- a/app/routes/_auth+/login.tsx
+++ b/app/routes/_auth+/login.tsx
@@ -18,6 +18,7 @@ import {
 	ProviderConnectionForm,
 	providerNames,
 } from '#app/utils/connections.tsx'
+import { APP_NAME } from '#app/utils/constants.js'
 import { checkHoneypot } from '#app/utils/honeypot.server.ts'
 import { useIsPending } from '#app/utils/misc.tsx'
 import { PasswordSchema, UsernameSchema } from '#app/utils/user-validation.ts'
@@ -197,7 +198,7 @@ export default function LoginPage() {
 }
 
 export const meta: MetaFunction = () => {
-	return [{ title: 'Login to Epic Notes' }]
+	return [{ title: `Login to ${APP_NAME}` }]
 }
 
 export function ErrorBoundary() {

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -20,6 +20,7 @@ import { CheckboxField, ErrorList, Field } from '#app/components/forms.tsx'
 import { Spacer } from '#app/components/spacer.tsx'
 import { StatusButton } from '#app/components/ui/status-button.tsx'
 import { requireAnonymous, sessionKey, signup } from '#app/utils/auth.server.ts'
+import { APP_NAME } from '#app/utils/constants.js'
 import { prisma } from '#app/utils/db.server.ts'
 import { checkHoneypot } from '#app/utils/honeypot.server.ts'
 import { useIsPending } from '#app/utils/misc.tsx'
@@ -126,7 +127,7 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export const meta: MetaFunction = () => {
-	return [{ title: 'Setup Epic Notes Account' }]
+	return [{ title: `Setup ${APP_NAME} Account` }]
 }
 
 export default function SignupRoute() {

--- a/app/routes/_auth+/onboarding_.$provider.tsx
+++ b/app/routes/_auth+/onboarding_.$provider.tsx
@@ -31,6 +31,7 @@ import {
 	requireAnonymous,
 } from '#app/utils/auth.server.ts'
 import { ProviderNameSchema } from '#app/utils/connections.tsx'
+import { APP_NAME } from '#app/utils/constants.js'
 import { prisma } from '#app/utils/db.server.ts'
 import { useIsPending } from '#app/utils/misc.tsx'
 import { authSessionStorage } from '#app/utils/session.server.ts'
@@ -174,7 +175,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 }
 
 export const meta: MetaFunction = () => {
-	return [{ title: 'Setup Epic Notes Account' }]
+	return [{ title: `Setup ${APP_NAME} Account` }]
 }
 
 export default function SignupRoute() {

--- a/app/routes/_auth+/reset-password.tsx
+++ b/app/routes/_auth+/reset-password.tsx
@@ -12,6 +12,7 @@ import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
 import { ErrorList, Field } from '#app/components/forms.tsx'
 import { StatusButton } from '#app/components/ui/status-button.tsx'
 import { requireAnonymous, resetUserPassword } from '#app/utils/auth.server.ts'
+import { APP_NAME } from '#app/utils/constants.js'
 import { useIsPending } from '#app/utils/misc.tsx'
 import { PasswordAndConfirmPasswordSchema } from '#app/utils/user-validation.ts'
 import { verifySessionStorage } from '#app/utils/verification.server.ts'
@@ -63,7 +64,7 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export const meta: MetaFunction = () => {
-	return [{ title: 'Reset Password | Epic Notes' }]
+	return [{ title: `Reset Password | ${APP_NAME}` }]
 }
 
 export default function ResetPasswordPage() {

--- a/app/routes/_auth+/signup.tsx
+++ b/app/routes/_auth+/signup.tsx
@@ -17,6 +17,7 @@ import {
 	ProviderConnectionForm,
 	providerNames,
 } from '#app/utils/connections.tsx'
+import { APP_NAME } from '#app/utils/constants.js'
 import { prisma } from '#app/utils/db.server.ts'
 import { sendEmail } from '#app/utils/email.server.ts'
 import { checkHoneypot } from '#app/utils/honeypot.server.ts'
@@ -66,7 +67,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 	const response = await sendEmail({
 		to: email,
-		subject: `Welcome to Epic Notes!`,
+		subject: `Welcome to ${APP_NAME}!`,
 		react: <SignupEmail onboardingUrl={verifyUrl.toString()} otp={otp} />,
 	})
 
@@ -95,7 +96,7 @@ export function SignupEmail({
 		<E.Html lang="en" dir="ltr">
 			<E.Container>
 				<h1>
-					<E.Text>Welcome to Epic Notes!</E.Text>
+					<E.Text>Welcome to {APP_NAME}!</E.Text>
 				</h1>
 				<p>
 					<E.Text>
@@ -112,7 +113,7 @@ export function SignupEmail({
 }
 
 export const meta: MetaFunction = () => {
-	return [{ title: 'Sign Up | Epic Notes' }]
+	return [{ title: `Sign Up | ${APP_NAME}` }]
 }
 
 export default function SignupRoute() {

--- a/app/routes/_marketing+/index.tsx
+++ b/app/routes/_marketing+/index.tsx
@@ -5,10 +5,11 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from '#app/components/ui/tooltip.tsx'
+import { APP_NAME } from '#app/utils/constants.js'
 import { cn } from '#app/utils/misc.tsx'
 import { logos } from './logos/logos.ts'
 
-export const meta: MetaFunction = () => [{ title: 'Epic Notes' }]
+export const meta: MetaFunction = () => [{ title: APP_NAME }]
 
 // Tailwind Grid cell classes lookup
 const columnClasses: Record<(typeof logos)[number]['column'], string> = {
@@ -50,13 +51,13 @@ export default function Index() {
 					</a>
 					<h1
 						data-heading
-						className="mt-8 animate-slide-top text-4xl font-medium text-foreground [animation-fill-mode:backwards] [animation-delay:0.3s] md:text-5xl xl:mt-4 xl:animate-slide-left xl:text-6xl xl:[animation-fill-mode:backwards] xl:[animation-delay:0.8s]"
+						className="mt-8 animate-slide-top text-4xl font-medium text-foreground [animation-delay:0.3s] [animation-fill-mode:backwards] md:text-5xl xl:mt-4 xl:animate-slide-left xl:text-6xl xl:[animation-delay:0.8s] xl:[animation-fill-mode:backwards]"
 					>
 						<a href="https://www.epicweb.dev/stack">The Epic Stack</a>
 					</h1>
 					<p
 						data-paragraph
-						className="mt-6 animate-slide-top text-xl/7 text-muted-foreground [animation-fill-mode:backwards] [animation-delay:0.8s] xl:mt-8 xl:animate-slide-left xl:text-xl/6 xl:leading-10 xl:[animation-fill-mode:backwards] xl:[animation-delay:1s]"
+						className="mt-6 animate-slide-top text-xl/7 text-muted-foreground [animation-delay:0.8s] [animation-fill-mode:backwards] xl:mt-8 xl:animate-slide-left xl:text-xl/6 xl:leading-10 xl:[animation-delay:1s] xl:[animation-fill-mode:backwards]"
 					>
 						Check the{' '}
 						<a

--- a/app/routes/settings+/profile.change-email.server.tsx
+++ b/app/routes/settings+/profile.change-email.server.tsx
@@ -5,6 +5,7 @@ import {
 	requireRecentVerification,
 	type VerifyFunctionArgs,
 } from '#app/routes/_auth+/verify.server.ts'
+import { APP_NAME } from '#app/utils/constants.js'
 import { prisma } from '#app/utils/db.server.ts'
 import { sendEmail } from '#app/utils/email.server.ts'
 import { redirectWithToast } from '#app/utils/toast.server.ts'
@@ -79,7 +80,7 @@ export function EmailChangeEmail({
 		<E.Html lang="en" dir="ltr">
 			<E.Container>
 				<h1>
-					<E.Text>Epic Notes Email Change</E.Text>
+					<E.Text>{APP_NAME} Email Change</E.Text>
 				</h1>
 				<p>
 					<E.Text>
@@ -100,11 +101,11 @@ function EmailChangeNoticeEmail({ userId }: { userId: string }) {
 		<E.Html lang="en" dir="ltr">
 			<E.Container>
 				<h1>
-					<E.Text>Your Epic Notes email has been changed</E.Text>
+					<E.Text>Your {APP_NAME} email has been changed</E.Text>
 				</h1>
 				<p>
 					<E.Text>
-						We're writing to let you know that your Epic Notes email has been
+						We're writing to let you know that your {APP_NAME} email has been
 						changed.
 					</E.Text>
 				</p>

--- a/app/routes/settings+/profile.change-email.tsx
+++ b/app/routes/settings+/profile.change-email.tsx
@@ -17,6 +17,7 @@ import {
 	requireRecentVerification,
 } from '#app/routes/_auth+/verify.server.ts'
 import { requireUserId } from '#app/utils/auth.server.ts'
+import { APP_NAME } from '#app/utils/constants.js'
 import { prisma } from '#app/utils/db.server.ts'
 import { sendEmail } from '#app/utils/email.server.ts'
 import { useIsPending } from '#app/utils/misc.tsx'
@@ -84,7 +85,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 	const response = await sendEmail({
 		to: submission.value.email,
-		subject: `Epic Notes Email Change Verification`,
+		subject: `${APP_NAME} Email Change Verification`,
 		react: <EmailChangeEmail verifyUrl={verifyUrl.toString()} otp={otp} />,
 	})
 

--- a/app/routes/users+/$username.tsx
+++ b/app/routes/users+/$username.tsx
@@ -5,6 +5,7 @@ import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
 import { Spacer } from '#app/components/spacer.tsx'
 import { Button } from '#app/components/ui/button.tsx'
 import { Icon } from '#app/components/ui/icon.tsx'
+import { APP_NAME } from '#app/utils/constants.js'
 import { prisma } from '#app/utils/db.server.ts'
 import { getUserImgSrc } from '#app/utils/misc.tsx'
 import { useOptionalUser } from '#app/utils/user.ts'
@@ -101,10 +102,10 @@ export default function ProfileRoute() {
 export const meta: MetaFunction<typeof loader> = ({ data, params }) => {
 	const displayName = data?.user.name ?? params.username
 	return [
-		{ title: `${displayName} | Epic Notes` },
+		{ title: `${displayName} | ${APP_NAME}` },
 		{
 			name: 'description',
-			content: `Profile of ${displayName} on Epic Notes`,
+			content: `Profile of ${displayName} on ${APP_NAME}`,
 		},
 	]
 }

--- a/app/routes/users+/$username_+/notes.$noteId.tsx
+++ b/app/routes/users+/$username_+/notes.$noteId.tsx
@@ -22,6 +22,7 @@ import { Button } from '#app/components/ui/button.tsx'
 import { Icon } from '#app/components/ui/icon.tsx'
 import { StatusButton } from '#app/components/ui/status-button.tsx'
 import { requireUserId } from '#app/utils/auth.server.ts'
+import { APP_NAME } from '#app/utils/constants.js'
 import { prisma } from '#app/utils/db.server.ts'
 import { getNoteImgSrc, useIsPending } from '#app/utils/misc.tsx'
 import { requireUserWithPermission } from '#app/utils/permissions.server.ts'
@@ -199,7 +200,7 @@ export const meta: MetaFunction<
 			? data?.note.content.slice(0, 97) + '...'
 			: 'No content'
 	return [
-		{ title: `${noteTitle} | ${displayName}'s Notes | Epic Notes` },
+		{ title: `${noteTitle} | ${displayName}'s Notes | ${APP_NAME}` },
 		{
 			name: 'description',
 			content: noteContentsSummary,

--- a/app/routes/users+/$username_+/notes.index.tsx
+++ b/app/routes/users+/$username_+/notes.index.tsx
@@ -1,4 +1,5 @@
 import { type MetaFunction } from '@remix-run/react'
+import { APP_NAME } from '#app/utils/constants.js'
 import { type loader as notesLoader } from './notes.tsx'
 
 export default function NotesIndexRoute() {
@@ -20,10 +21,10 @@ export const meta: MetaFunction<
 	const noteCount = notesMatch?.data?.owner.notes.length ?? 0
 	const notesText = noteCount === 1 ? 'note' : 'notes'
 	return [
-		{ title: `${displayName}'s Notes | Epic Notes` },
+		{ title: `${displayName}'s Notes | ${APP_NAME}` },
 		{
 			name: 'description',
-			content: `Checkout ${displayName}'s ${noteCount} ${notesText} on Epic Notes`,
+			content: `Checkout ${displayName}'s ${noteCount} ${notesText} on ${APP_NAME}`,
 		},
 	]
 }

--- a/app/routes/users+/index.tsx
+++ b/app/routes/users+/index.tsx
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
 import { ErrorList } from '#app/components/forms.tsx'
 import { SearchBar } from '#app/components/search-bar.tsx'
+import { APP_NAME } from '#app/utils/constants.js'
 import { prisma } from '#app/utils/db.server.ts'
 import { cn, getUserImgSrc, useDelayedIsPending } from '#app/utils/misc.tsx'
 
@@ -61,7 +62,7 @@ export default function UsersRoute() {
 
 	return (
 		<div className="container mb-48 mt-36 flex flex-col items-center justify-center gap-6">
-			<h1 className="text-h1">Epic Notes Users</h1>
+			<h1 className="text-h1">{APP_NAME} Users</h1>
 			<div className="w-full max-w-[700px]">
 				<SearchBar status={data.status} autoFocus autoSubmit />
 			</div>

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -1,0 +1,2 @@
+// Don't forgot to update site.webmanifest as well
+export const APP_NAME = 'Epic Notes'

--- a/tests/e2e/search.test.ts
+++ b/tests/e2e/search.test.ts
@@ -1,4 +1,5 @@
 import { invariant } from '@epic-web/invariant'
+import { APP_NAME } from '#app/utils/constants.js'
 import { expect, test } from '#tests/playwright-utils.ts'
 
 test('Search from home page', async ({ page, insertNewUser }) => {
@@ -11,7 +12,7 @@ test('Search from home page', async ({ page, insertNewUser }) => {
 	await page.waitForURL(
 		`/users?${new URLSearchParams({ search: newUser.username })}`,
 	)
-	await expect(page.getByText('Epic Notes Users')).toBeVisible()
+	await expect(page.getByText(`${APP_NAME} Users`)).toBeVisible()
 	const userList = page.getByRole('main').getByRole('list')
 	await expect(userList.getByRole('listitem')).toHaveCount(1)
 	invariant(newUser.name, 'User name not found')


### PR DESCRIPTION
## Intro

Hello! Just wanted to say I'm using this for a new project and I'm super pumped to have found this. Thank you to all contributors for everything you've done to make this great. 

As I was getting my project bootstrapped, I noticed a few things that could help speed up getting up and running and this PR covers one of them.

If any of the changes are undesirable or don't follow conventions, please let me know and I can adjust accordingly!

## Summary

Moves all instances of `Epic Notes` to a single file so new Epic Stack users can modify a single line and have it propagate to all instances where that constant is used.

Note: In `root.tsx`, I split the `APP_NAME` value on spaces and then try to render the first word and all remaining words so there is one less place for developers to modify, at least early on. 

## Test Plan

I didn't add any additional tests, but I can if helpful. `search.test.ts` was checking for the string Epic Notes, and that test is still passing.

## Checklist

- [x] Tests updated
- [x] Docs updated (no changes needed)

## Screenshots

Screenshots showcase no regressions in the UI:

![Screenshot 2024-05-09 at 1 48 11 PM](https://github.com/epicweb-dev/epic-stack/assets/246603/ab74f19f-bd07-436c-a3c1-865ebbd8e9e0)
![Screenshot 2024-05-09 at 1 49 01 PM](https://github.com/epicweb-dev/epic-stack/assets/246603/a2ac61d2-568e-422b-af4e-fc2d4f7f5fb1)
![Screenshot 2024-05-09 at 1 49 16 PM](https://github.com/epicweb-dev/epic-stack/assets/246603/0a050664-4e7f-4fbf-82be-eb2e9111d131)

### Behavior For 1-Word And 3+ Word App Name
![Screenshot 2024-05-09 at 1 52 25 PM](https://github.com/epicweb-dev/epic-stack/assets/246603/8d0f7cff-be11-455b-894e-777a4686376b)

![Screenshot 2024-05-09 at 1 52 33 PM](https://github.com/epicweb-dev/epic-stack/assets/246603/2acce68e-bcb6-4429-8c59-ae5c1fa96edb)

