### PR TITLE
fix: ignore generated icons folder

### DIFF
--- a/remix.init/gitignore
+++ b/remix.init/gitignore
@@ -20,3 +20,6 @@ node_modules
 
 # Easy way to create temporary files/folders that won't accidentally be added to git
 *.local.*
+
+# generated files
+/app/components/ui/icons


### PR DESCRIPTION
When an app is created with create-epic-app, the gitignore file does not include /app/components/ui/icons

## Test Plan

1. `npx create-epic-app`
2. Look at the `.gitignore` file
