### PR TITLE
feat: restrict path aliases to app and test folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com/)",
   "type": "module",
   "imports": {
-    "#*": "./*"
+    "#app/*": "./app/*",
+    "#tests/*": "./tests/*"
   },
   "scripts": {
     "build": "run-s build:*",

--- a/server/index.ts
+++ b/server/index.ts
@@ -201,7 +201,7 @@ async function getBuild() {
 		? viteDevServer.ssrLoadModule('virtual:remix/server-build')
 		: // @ts-ignore this should exist before running the server
 			// but it may not exist just yet.
-			await import('#build/server/index.js')
+			await import('../build/server/index.js')
 	// not sure how to make this happy 🤷‍♂️
 	return build as unknown as ServerBuild
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
     "paths": {
-      "#*": ["./*"],
+      "#app/*": ["./app/*"],
+      "#tests/*": ["./tests/*"],
       "@/icon-name": [
         "./app/components/ui/icons/name.d.ts",
         "./types/icon-name.d.ts"


### PR DESCRIPTION
If another project is ever added to the same repository, you'll want to restrict the way projects import from each other.  Creating path aliases for `/app` and `/test` allows all the current code to work in the same way it currently does, while leaving open the possibility of adding an `app2` alias in the future that is handled differently.
