### PR TITLE
Pedantic grammar fix in init script

### DIFF
--- a/remix.init/index.mjs
+++ b/remix.init/index.mjs
@@ -113,7 +113,7 @@ async function setupDeployment({ rootDirectory }) {
 			name: 'shouldSetupDeployment',
 			type: 'confirm',
 			default: true,
-			message: 'Would you like to setup deployment right now?',
+			message: 'Would you like to set up deployment right now?',
 		},
 	])
 


### PR DESCRIPTION
"setup" is a noun and "set up" is a verb. This updates the init script to choose the correct one.

## Test Plan

n/a

## Checklist

n/a

## Screenshots

n/a
