### PR TITLE
Error Logging

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -13,6 +13,7 @@ import { getEnv, init } from './utils/env.server.ts'
 import { getInstanceInfo } from './utils/litefs.server.ts'
 import { NonceProvider } from './utils/nonce-provider.ts'
 import { makeTimings } from './utils/timing.server.ts'
+import chalk from 'chalk'
 
 const ABORT_DELAY = 5000
 
@@ -97,9 +98,16 @@ export function handleError(
 	error: unknown,
 	{ request }: LoaderFunctionArgs | ActionFunctionArgs,
 ): void {
+	// Skip capturing if the request is aborted as Remix docs suggest
+	// Ref: https://remix.run/docs/en/main/file-conventions/entry.server#handleerror
+	if (request.signal.aborted) {
+		return
+	}
 	if (error instanceof Error) {
+		console.error(chalk.red(error.stack))
 		Sentry.captureRemixServerException(error, 'remix.server', request)
 	} else {
+		console.error(chalk.red(error))
 		Sentry.captureException(error)
 	}
 }


### PR DESCRIPTION
Currently, errors are not logged to the console, only to Sentry (if it's enabled)

## Test Plan

This was manually tested

## Checklist

- ~[ ] Tests updated~ -- additional tests unnecessary, as it's just logging to the console
- ~[ ] Docs updated~ -- updating docs unnecessary, as this will be the expected behavior

## Screenshots
Previously, only an 500  status was reported, but not the error itself:
<img width="490" alt="Screenshot 2024-05-17 at 6 16 42 PM" src="https://github.com/epicweb-dev/epic-stack/assets/4328800/eb996da5-ec2e-45be-b073-eac9e91ee8b5">

We now get the full error and stack trace along with the HTTP status:
<img width="671" alt="Screenshot 2024-05-17 at 7 14 17 PM" src="https://github.com/epicweb-dev/epic-stack/assets/4328800/884afffb-e7ab-403b-990c-c06b134c60db">