### PR TITLE
Pr/error logging

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -7,13 +7,13 @@ import {
 } from '@remix-run/node'
 import { RemixServer } from '@remix-run/react'
 import * as Sentry from '@sentry/remix'
+import chalk from 'chalk'
 import { isbot } from 'isbot'
 import { renderToPipeableStream } from 'react-dom/server'
 import { getEnv, init } from './utils/env.server.ts'
 import { getInstanceInfo } from './utils/litefs.server.ts'
 import { NonceProvider } from './utils/nonce-provider.ts'
 import { makeTimings } from './utils/timing.server.ts'
-import chalk from 'chalk'
 
 const ABORT_DELAY = 5000
 
@@ -71,10 +71,8 @@ export default async function handleRequest(...args: DocRequestArgs) {
 				onShellError: (err: unknown) => {
 					reject(err)
 				},
-				onError: (error: unknown) => {
+				onError: () => {
 					didError = true
-
-					console.error(error)
 				},
 				nonce,
 			},


### PR DESCRIPTION
Fixes bug in #735, where errors would get logged 2X when the error originated in the client code.

I've removed the duplicate error logging, so now, all errors are logged, and they are only logged one time.

## Test Plan

This was manually tested.

## Checklist

- ~[ ] Tests updated~ -- additional tests unnecessary, as it's just logging to the console
- ~[ ] Docs updated~ -- updating docs unnecessary, as this will be the expected behavior

## Screenshots

Before, error thrown within React code is logged 2X:
<img width="671" alt="Screenshot 2024-05-18 at 1 44 48 PM" src="https://github.com/epicweb-dev/epic-stack/assets/4328800/dbda87e4-0a22-4fc1-9782-db269a9d487f">

After, they're logged only once:
<img width="601" alt="Screenshot 2024-05-18 at 1 45 21 PM" src="https://github.com/epicweb-dev/epic-stack/assets/4328800/ee9ff90b-b2c0-4e86-805a-b93f26245373">
