### PR TITLE
add RESEND_API_KEY to Dockerfile and deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,6 +167,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/dev' }}
         run:
           flyctl deploy --remote-only --build-arg COMMIT_SHA=${{ github.sha }}
+          --build-arg RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
           --app ${{ steps.app_name.outputs.value }}-staging
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
@@ -176,5 +177,6 @@ jobs:
         run:
           flyctl deploy --remote-only --build-arg COMMIT_SHA=${{ github.sha }}
           --build-secret SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+          --build-arg RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/other/Dockerfile
+++ b/other/Dockerfile
@@ -61,6 +61,8 @@ ENV PORT="8081"
 ENV NODE_ENV="production"
 # For WAL support: https://github.com/prisma/prisma-engines/issues/4675#issuecomment-1914383246
 ENV PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK = "1"
+ARG RESEND_API_KEY
+ENV RESEND_API_KEY=$RESEND_API_KEY
 
 # add shortcut for connecting to database CLI
 RUN echo "#!/bin/sh\nset -x\nsqlite3 \$DATABASE_URL" > /usr/local/bin/database-cli && chmod +x /usr/local/bin/database-cli


### PR DESCRIPTION
This adds the `RESEND_API_KEY` env var to the `Dockerfile` and `deploy.yml`

Submitting this PR as it worked for me, I'm not sure if there was already another way to do it.

## Test Plan

Set the value of `RESEND_API_KEY` as a secret in github and deploy with Github Actions as usual.

## Checklist

- [ ] Tests updated
- [ ] Docs updated