### PR TITLE
specify Dockerfile and .dockerignore in fly.toml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,12 +154,6 @@ jobs:
           file: 'fly.toml'
           field: 'app'
 
-      # move Dockerfile to root
-      - name: 🚚 Move Dockerfile
-        run: |
-          mv ./other/Dockerfile ./Dockerfile
-          mv ./other/.dockerignore ./.dockerignore
-
       - name: 🎈 Setup Fly
         uses: superfly/flyctl-actions/setup-flyctl@1.5
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -130,28 +130,19 @@ Find instructions for this optional step in [the database docs](./database.md).
 
 ## Deploying locally using fly
 
-If you'd like to deploy locally you definitely can. You need to (temporarily)
-move the `Dockerfile` and the `.dockerignore` to the root of the project first.
-Then you can run the deploy command:
+If you'd like to deploy locally you definitely can with
 
 ```
-mv ./other/Dockerfile Dockerfile
-mv ./other/.dockerignore .dockerignore
 fly deploy
 ```
 
-Once it's done, move the files back:
-
-```
-mv Dockerfile ./other/Dockerfile
-mv .dockerignore ./other/.dockerignore
-```
-
-You can keep the `Dockerfile` and `.dockerignore` in the root if you prefer,
-just make sure to remove the move step from the `.github/workflows/deploy.yml`.
-
 ## Deploying locally using docker/podman
-If you'd like to deploy locally by building a docker container image, you definitely can. For that you need to make some minimal changes to the Dockerfile located at other/Dockerfile. Remove everything from the line that says (#prepare for litefs) in "other/Dockerfile" till the end of file and swap with the contents below.
+
+If you'd like to deploy locally by building a docker container image, you
+definitely can. For that you need to make some minimal changes to the Dockerfile
+located at other/Dockerfile. Remove everything from the line that says (#prepare
+for litefs) in "other/Dockerfile" till the end of file and swap with the
+contents below.
 
 ```
 # prepare for litefs
@@ -162,11 +153,14 @@ EXPOSE ${PORT}
 ENTRYPOINT ["/myapp/other/docker-entry-point.sh"]
 ```
 
-There are 2 things that we are doing here. 
+There are 2 things that we are doing here.
+
 1. docker volume is used to swap out the fly.io litefs mount.
-2. Docker ENTRYPOINT is used to execute some commands upon launching of the docker container
+2. Docker ENTRYPOINT is used to execute some commands upon launching of the
+   docker container
 
 Create a file at other/docker-entry-point.sh with the contents below.
+
 ```
 #!/bin/sh -ex
 
@@ -175,9 +169,12 @@ sqlite3 /litefs/data/sqlite.db "PRAGMA journal_mode = WAL;"
 sqlite3 /litefs/data/cache.db "PRAGMA journal_mode = WAL;"
 npm run start
 ```
-This takes care of applying the prisma migrations, followed by launching the node application (on port 8081). 
+
+This takes care of applying the prisma migrations, followed by launching the
+node application (on port 8081).
 
 Helpful commands:
+
 ```
 docker build -t epic-stack . -f other/Dockerfile --build-arg COMMIT_SHA=`git rev-parse --short HEAD` # builds the docker container
 mkdir ~/litefs # mountpoint for your sqlite databases

--- a/fly.toml
+++ b/fly.toml
@@ -5,6 +5,10 @@ kill_timeout = 5
 processes = [ ]
 swap_size_mb = 512
 
+[build]
+dockerfile = "other/Dockerfile"
+ignorefile = "other/.dockerignore"
+
 [experimental]
 allowed_public_ports = [ ]
 auto_rollback = true

--- a/other/.dockerignore
+++ b/other/.dockerignore
@@ -1,5 +1,3 @@
-# This file is moved to the root directory before building the image
-
 /node_modules
 *.log
 .DS_Store

--- a/other/Dockerfile
+++ b/other/Dockerfile
@@ -1,5 +1,3 @@
-# This file is moved to the root directory before building the image
-
 # base node image
 FROM node:20-bookworm-slim as base
 

--- a/remix.init/index.mjs
+++ b/remix.init/index.mjs
@@ -185,15 +185,6 @@ async function setupDeployment({ rootDirectory }) {
 	])
 	if (shouldDeploy) {
 		console.log(`🚀 Deploying apps...`)
-		console.log('  Moving Dockerfile and .dockerignore to root (temporarily)')
-		await fs.rename(
-			path.join(rootDirectory, 'other', 'Dockerfile'),
-			path.join(rootDirectory, 'Dockerfile'),
-		)
-		await fs.rename(
-			path.join(rootDirectory, 'other', '.dockerignore'),
-			path.join(rootDirectory, '.dockerignore'),
-		)
 		console.log(`  Starting with staging`)
 		await $I`fly deploy --app ${APP_NAME}-staging`
 		await open(`https://${APP_NAME}-staging.fly.dev/`)
@@ -202,15 +193,6 @@ async function setupDeployment({ rootDirectory }) {
 		await $I`fly deploy --app ${APP_NAME}`
 		await open(`https://${APP_NAME}.fly.dev/`)
 		console.log(`  Production deployed...`)
-		console.log('  Moving Dockerfile and .dockerignore back to other/')
-		await fs.rename(
-			path.join(rootDirectory, 'Dockerfile'),
-			path.join(rootDirectory, 'other', 'Dockerfile'),
-		)
-		await fs.rename(
-			path.join(rootDirectory, '.dockerignore'),
-			path.join(rootDirectory, 'other', '.dockerignore'),
-		)
 	}
 
 	const { shouldSetupGitHub } = await inquirer.prompt([


### PR DESCRIPTION
Moving the `Dockerfile` and `.dockerignore` is not ideal, as if the process gets interrupted, they will not be moved back to the correct location.

Utilize the [dockerfile](https://fly.io/docs/reference/configuration/#specify-a-docker-image) and [ignorefile](https://fly.io/docs/reference/configuration/#specify-a-docker-ignore-file) `fly.toml` options to specify the location of the `Dockerfile` and `.dockerignore`.

## Test Plan

I tested this in my own project to make this works as expected.

## Checklist

~- [ ] Tests updated~ see above
- [*] Docs updated
