### PR TITLE
fix nonce error with remix dev server

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -44,7 +44,7 @@ export default async function handleRequest(...args: DocRequestArgs) {
 		? 'onAllReady'
 		: 'onShellReady'
 
-	const nonce = String(loadContext.cspNonce) ?? undefined
+	const nonce = loadContext.cspNonce?.toString() ?? ''
 	return new Promise(async (resolve, reject) => {
 		let didError = false
 		// NOTE: this timing will only include things that are rendered in the shell


### PR DESCRIPTION
When running the dev server without a nonce, e.g. via `pnpm remix vite:dev -p 3000`, you currently get an error:

<img width="896" alt="Screenshot 2024-06-18 at 12 44 22 PM" src="https://github.com/epicweb-dev/epic-stack/assets/4328800/c2d94016-f136-4dc5-a841-92d9a137fbdc">

## Test Plan

Tested manually

## Checklist

- ~[ ] Tests updated~ See above
- ~[ ] Docs updated~ Not necessarily, just a bug fix

## Screenshots

See above
