### PR TITLE
Use Fly-Client-Ip as rate limit key

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -146,9 +146,14 @@ const rateLimitDefault = {
 	max: 1000 * maxMultiple,
 	standardHeaders: true,
 	legacyHeaders: false,
-	// Fly.io prevents spoofing of X-Forwarded-For
-	// so no need to validate the trustProxy config
 	validate: { trustProxy: false },
+	// Malicious users can spoof their IP address which means we should not deault
+	// to trusting req.ip when hosted on Fly.io. However, users cannot spoof Fly-Client-Ip.
+	// When sitting behind a CDN such as cloudflare, replace fly-client-ip with the CDN
+	// specific header such as cf-connecting-ip
+	keyGenerator: (req) => {
+		return req.get('fly-client-ip') ?? req.ip
+	},
 }
 
 const strongestRateLimit = rateLimit({


### PR DESCRIPTION
The ip used for rate limiting can be spoofed as detailed here https://github.com/epicweb-dev/epic-stack/issues/682

### Test Plan
In the browser, submit to a protected route such as login to trigger the rate limit.
Use curl or Postman to submit to the login endpoint but attempt to override the Fly-Client-Ip header for each request. Rate limiting should still be triggered