### PR TITLE
Add autofocus to OTP input

### DIFF
--- a/app/routes/_auth+/verify.tsx
+++ b/app/routes/_auth+/verify.tsx
@@ -104,6 +104,7 @@ export default function VerifyRoute() {
 								inputProps={{
 									...getInputProps(fields[codeQueryParam], { type: 'text' }),
 									autoComplete: 'one-time-code',
+									autoFocus: true,
 								}}
 								errors={fields[codeQueryParam].errors}
 							/>


### PR DESCRIPTION
Add autofocus to OTP input

## Test Plan

Login with 2FA enabled and verify that OTP field is autofocused.

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
