### PR TITLE
Fix hydration warning on script nonces

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -181,6 +181,7 @@ function Document({
 					dangerouslySetInnerHTML={{
 						__html: `window.ENV = ${JSON.stringify(env)}`,
 					}}
+					suppressHydrationWarning
 				/>
 				<ScrollRestoration nonce={nonce} />
 				<Scripts nonce={nonce} />

--- a/app/utils/client-hints.tsx
+++ b/app/utils/client-hints.tsx
@@ -46,6 +46,7 @@ export function ClientHintCheck({ nonce }: { nonce: string }) {
 			dangerouslySetInnerHTML={{
 				__html: hintsUtils.getClientHintCheckScript(),
 			}}
+			suppressHydrationWarning
 		/>
 	)
 }


### PR DESCRIPTION
<!-- Summary: Put your summary here -->

This PR just fixes the annoying hydration warning that appears on Firefox on script nonces:

<img width="513" alt="image" src="https://github.com/epicweb-dev/epic-stack/assets/21188659/27388296-e5bc-423f-80a9-670b24446e23">

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
