### PR TITLE
Fix `cleanupDb` when foreign key constraints exist

### DIFF
--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -121,9 +121,9 @@ export async function cleanupDb(prisma: PrismaClient) {
 	>`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations';`
 
 	try {
+		// Disable FK constraints to avoid relation conflicts during deletion
 		await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = OFF`)
 		await prisma.$transaction([
-			// Disable FK constraints to avoid relation conflicts during deletion
 			// Delete all rows from each table, preserving table structures
 			...tables.map(({ name }) =>
 				prisma.$executeRawUnsafe(`DELETE from "${name}"`),

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -129,10 +129,9 @@ export async function cleanupDb(prisma: PrismaClient) {
 				prisma.$executeRawUnsafe(`DELETE from "${name}"`),
 			),
 		])
-		await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = ON`)
 	} catch (error) {
 		console.error('Error cleaning up database:', error)
-		// Ensure FK constraints are re-enabled
+	} finally {
 		await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = ON`)
 	}
 }


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
PR to address https://github.com/epicweb-dev/epic-stack/issues/791 
## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->
If the `npm run setup` works as expected, the seeding and the db cleanup works correctly. 

To test this fix fully, we'd need to add some data to the database with FK constraints, not have `ON DELETE CASCADE` on it, and expect `cleanupDb` to succeed.

Also, another good test would be to monkey patch the `cleanupDb` to throw inside the transaction and expect `foreign_keys` to be still on (catch clause reached)

## Checklist

- [x] Tests updated - no tests need updating
- [x] Docs updated - no need

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
