### PR TITLE
fix expires date in playwright addCookies

### DIFF
--- a/tests/playwright-utils.ts
+++ b/tests/playwright-utils.ts
@@ -94,10 +94,14 @@ export const test = base.extend<{
 			authSession.set(sessionKey, session.id)
 			const cookieConfig = setCookieParser.parseString(
 				await authSessionStorage.commitSession(authSession),
-			) as any
-			await page
-				.context()
-				.addCookies([{ ...cookieConfig, domain: 'localhost' }])
+			)
+			const newConfig = {
+				...cookieConfig,
+				domain: 'localhost',
+				expires: cookieConfig.expires?.getTime(),
+				sameSite: cookieConfig.sameSite as 'Strict' | 'Lax' | 'None',
+			}
+			await page.context().addCookies([newConfig])
 			return user
 		})
 		await prisma.user.deleteMany({ where: { id: userId } })
@@ -113,7 +117,7 @@ export const test = base.extend<{
 
 		let ghUser: GitHubUser | null = null
 		await use(async () => {
-			const newGitHubUser = await insertGitHubUser(testInfo.testId)!
+			const newGitHubUser = await insertGitHubUser(testInfo.testId)
 			ghUser = newGitHubUser
 			return newGitHubUser
 		})

--- a/tests/playwright-utils.ts
+++ b/tests/playwright-utils.ts
@@ -117,7 +117,7 @@ export const test = base.extend<{
 
 		let ghUser: GitHubUser | null = null
 		await use(async () => {
-			const newGitHubUser = await insertGitHubUser(testInfo.testId)
+			const newGitHubUser = await insertGitHubUser(testInfo.testId)!
 			ghUser = newGitHubUser
 			return newGitHubUser
 		})


### PR DESCRIPTION
There are type difference between set-cookie-parser and playwright cookies.

`expires` in cookie-parser is `Date | undefined`
playwright addCookies use `number | undefined'`

This PR convert the Date to number using `getTime`