### PR TITLE
allow connection to hmr server locally

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -115,7 +115,7 @@ app.use(
 			reportOnly: true,
 			directives: {
 				'connect-src': [
-					MODE === 'development' ? 'ws:' : null,
+					...(MODE === 'development' ? ['ws:', 'localhost:24678'] : []),
 					process.env.SENTRY_DSN ? '*.sentry.io' : null,
 					"'self'",
 				].filter(Boolean),


### PR DESCRIPTION
Vite's hot module reload server is on this port. This opens the CSP to connect to it in dev.