### PR TITLE
build(remix): don't use `installGlobals`

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto'
 import { createRequestHandler } from '@remix-run/express'
-import { type ServerBuild, installGlobals } from '@remix-run/node'
+import { type ServerBuild } from '@remix-run/node'
 import { ip as ipAddress } from 'address'
 import chalk from 'chalk'
 import closeWithGrace from 'close-with-grace'
@@ -10,8 +10,6 @@ import rateLimit from 'express-rate-limit'
 import getPort, { portNumbers } from 'get-port'
 import helmet from 'helmet'
 import morgan from 'morgan'
-
-installGlobals()
 
 const MODE = process.env.NODE_ENV ?? 'development'
 const IS_PROD = MODE === 'production'

--- a/tests/setup/custom-matchers.ts
+++ b/tests/setup/custom-matchers.ts
@@ -74,7 +74,7 @@ expect.extend({
 		}
 	},
 	async toHaveSessionForUser(response: Response, userId: string) {
-		const setCookies = getSetCookie(response.headers)
+		const setCookies = response.headers.getSetCookie()
 		const sessionSetCookie = setCookies.find(
 			(c) => setCookieParser.parseString(c).name === 'en_session',
 		)
@@ -115,7 +115,7 @@ expect.extend({
 		}
 	},
 	async toSendToast(response: Response, toast: ToastInput) {
-		const setCookies = getSetCookie(response.headers)
+		const setCookies = response.headers.getSetCookie()
 		const toastSetCookie = setCookies.find(
 			(c) => setCookieParser.parseString(c).name === 'en_toast',
 		)
@@ -163,12 +163,4 @@ interface CustomMatchers<R = unknown> {
 declare module 'vitest' {
 	interface Assertion<T = any> extends CustomMatchers<T> {}
 	interface AsymmetricMatchersContaining extends CustomMatchers {}
-}
-
-function getSetCookie(headers: Headers) {
-	// this is a sort of polyfill for headers.getSetCookie
-	// https://github.com/microsoft/TypeScript/issues/55270
-	// https://github.com/remix-run/remix/issues/7067
-	// @ts-expect-error see the two issues above
-	return headers.getAll('set-cookie') as Array<string>
 }

--- a/tests/setup/setup-test-env.ts
+++ b/tests/setup/setup-test-env.ts
@@ -3,13 +3,10 @@ import './db-setup.ts'
 import '#app/utils/env.server.ts'
 // we need these to be imported first 👆
 
-import { installGlobals } from '@remix-run/node'
 import { cleanup } from '@testing-library/react'
 import { afterEach, beforeEach, vi, type MockInstance } from 'vitest'
 import { server } from '#tests/mocks/index.ts'
 import './custom-matchers.ts'
-
-installGlobals()
 
 afterEach(() => server.resetHandlers())
 afterEach(() => cleanup())


### PR DESCRIPTION
The globals that were installed with `installGlobals` are now provided by `node` itself.

The one major change is removing `getSetCookie` helper method that was used as a hack.

## Test Plan

The current tests should pass.

## Checklist

- [x] Tests updated

## Screenshots

No change that requires screenshot change.

closes: #802
