### PR TITLE
Store epic-stack latest commit hash in the package.json

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,48 @@
+name: 🔖 Version
+on:
+  push:
+    branches:
+      - main
+      - dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  version:
+    name: 🚀 Update Version
+    runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'push' }}
+
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+
+      - name: 🔢 Get HEAD commit hash
+        id: get_head_hash
+        run: echo "HEAD_HASH=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: 📝 Update package.json
+        run: |
+          jq '
+            if .["epic-stack"] == true then
+              .["epic-stack"] = {"head": "${{ steps.get_head_hash.outputs.HEAD_HASH }}"}
+            elif .["epic-stack"] then
+              .["epic-stack"].head = "${{ steps.get_head_hash.outputs.HEAD_HASH }}"
+            else
+              .["epic-stack"] = {"head": "${{ steps.get_head_hash.outputs.HEAD_HASH }}"}
+            end
+          ' package.json > temp.json && mv temp.json package.json
+
+      - name: 💾 Commit changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add package.json
+          git commit -m "Update epic-stack.head in package.json [skip ci]"
+          git push

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -26,22 +26,29 @@ jobs:
         id: get_head_hash
         run: echo "HEAD_HASH=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
+      - name: 📅 Get current date
+        id: get_date
+        run:
+          echo "CURRENT_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
       - name: 📝 Update package.json
         run: |
           jq '
-            if .["epic-stack"] == true then
-              .["epic-stack"] = {"head": "${{ steps.get_head_hash.outputs.HEAD_HASH }}"}
-            elif .["epic-stack"] then
-              .["epic-stack"].head = "${{ steps.get_head_hash.outputs.HEAD_HASH }}"
+            if .["epic-stack"] then
+              .["epic-stack"].head = "${{ steps.get_head_hash.outputs.HEAD_HASH }}" |
+              .["epic-stack"].date = "${{ steps.get_date.outputs.CURRENT_DATE }}"
             else
-              .["epic-stack"] = {"head": "${{ steps.get_head_hash.outputs.HEAD_HASH }}"}
+              .["epic-stack"] = {
+                "head": "${{ steps.get_head_hash.outputs.HEAD_HASH }}",
+                "date": "${{ steps.get_date.outputs.CURRENT_DATE }}"
+              }
             end
           ' package.json > temp.json && mv temp.json package.json
 
       - name: 💾 Commit changes
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "kody@epicweb.com"
+          git config --local user.name "kody"
           git add package.json
-          git commit -m "Update epic-stack.head in package.json [skip ci]"
+          git commit -m "Update epic-stack.head and epic-stack.date in package.json [skip ci]"
           git push

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -50,5 +50,5 @@ jobs:
           git config --local user.email "kody@epicweb.com"
           git config --local user.name "kody"
           git add package.json
-          git commit -m "Update epic-stack.head and epic-stack.date in package.json [skip ci]"
+          git commit -m "Update epic-stack version [skip ci]"
           git push

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,8 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  actions: write
-  contents: read
+  contents: write
 
 jobs:
   version:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: 💾 Commit changes
         run: |
-          git config --local user.email "kody@epicweb.com"
+          git config --local user.email "kody@epicweb.dev"
           git config --local user.name "kody"
           git add package.json
           git commit -m "Update epic-stack version [skip ci]"

--- a/docs/managing-updates.md
+++ b/docs/managing-updates.md
@@ -48,6 +48,9 @@ peruse
 [the Epic Stack's commit history](https://github.com/epicweb-dev/epic-stack/commits/main)
 anytime you'd like to see what updates could be made to your project.
 
+Check the [epic-stack field in the package.json file](../package.json) to see
+what the date and commit hash were when you created your project.
+
 ## How to update NPM dependencies
 
 Another part of the Epic Stack is the dependencies of the project. These you

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "sideEffects": false,
   "license": "MIT",
   "epic-stack": {
-    "head": "a78803f8fc95eda8f63e2532e11a0184ab3c5134",
-    "date": "2024-07-25T17:16:00Z"
+    "head": "6c9d4d2b353e54d70f0378854af95c4cdfd6515e",
+    "date": "2024-08-03T00:02:41Z"
   },
   "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com/)",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "sideEffects": false,
   "license": "MIT",
-  "epic-stack": true,
+  "epic-stack": {
+    "head": "fd1594dd8db05ed949abee992ec1354368d57599"
+  },
   "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com/)",
   "type": "module",
   "imports": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "sideEffects": false,
   "license": "MIT",
   "epic-stack": {
-    "head": "fd1594dd8db05ed949abee992ec1354368d57599"
+    "head": "ab8229dfce8377c9d0bf3cd9f7d4406833c808f4"
   },
   "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com/)",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "sideEffects": false,
   "license": "MIT",
   "epic-stack": {
-    "head": "ab8229dfce8377c9d0bf3cd9f7d4406833c808f4"
+    "head": "0013030c7155acf527634ca33358ee3e84a3cb75",
+    "date": "2024-07-25T17:12:08Z"
   },
   "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com/)",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "sideEffects": false,
   "license": "MIT",
   "epic-stack": {
-    "head": "0013030c7155acf527634ca33358ee3e84a3cb75",
-    "date": "2024-07-25T17:12:08Z"
+    "head": "a78803f8fc95eda8f63e2532e11a0184ab3c5134",
+    "date": "2024-07-25T17:16:00Z"
   },
   "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com/)",
   "type": "module",

--- a/remix.init/index.mjs
+++ b/remix.init/index.mjs
@@ -66,6 +66,7 @@ export default async function main({ rootDirectory }) {
 		fs.rm(path.join(rootDirectory, 'docs'), { recursive: true }),
 		fs.rm(path.join(rootDirectory, 'tests/e2e/notes.test.ts')),
 		fs.rm(path.join(rootDirectory, 'tests/e2e/search.test.ts')),
+		fs.rm(path.join(rootDirectory, '.github/workflows/version.yml')),
 	]
 
 	await Promise.all(fileOperationPromises)


### PR DESCRIPTION
This PR adds a new Github Actions workflow that writes the current HEAD commit and the date to the package.json as a version tracking scheme. Epic Stack apps can use this to see when they detached from the original epic stack when trying to follow along with changes.

Anyone who clones the repo or uses `npx create remix --template` or `npx create epic-app` will have that hash automatically, 

During this setup step, the version action is removed so it won't affect consumers of the stack in an ongoing basis. 

Future automated tooling 👀 👀 👀  could use this to apply a series of commits automatically

This only applies during pushes to main/dev, all the extra commits in this PR come from that I was pushing to main directly to test it. 
