### PR TITLE
Improve docker ignorefile honoring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,12 +156,6 @@ jobs:
           file: 'fly.toml'
           field: 'app'
 
-      # move Dockerfile to root
-      - name: 🚚 Move Dockerfile
-        run: |
-          mv ./other/Dockerfile ./Dockerfile
-          mv ./other/.dockerignore ./.dockerignore
-
       - name: 🎈 Setup Fly
         uses: superfly/flyctl-actions/setup-flyctl@1.5
 

--- a/fly.toml
+++ b/fly.toml
@@ -13,6 +13,10 @@ auto_rollback = true
 source = "data"
 destination = "/data"
 
+[build]
+dockerfile = "/other/Dockerfile"
+ignorefile = "/other/Dockerfile.dockerignore"
+
 [[services]]
 internal_port = 8080
 processes = [ "app" ]

--- a/other/.dockerignore
+++ b/other/.dockerignore
@@ -1,9 +1,0 @@
-# This file is moved to the root directory before building the image
-
-/node_modules
-*.log
-.DS_Store
-.env
-/.cache
-/public/build
-/build

--- a/other/Dockerfile.dockerignore
+++ b/other/Dockerfile.dockerignore
@@ -1,0 +1,9 @@
+# This file is moved to the root directory before building the image
+
+/node_modules
+*.log
+.DS_Store
+.env
+/.cache
+/public/build
+/build


### PR DESCRIPTION
`.dockerignore` files are only honored at project root, this PR changes the name to `Dockerfile.dockerignore` which makes docker actually honor the given patterns no matter on which path the ignorefile lives.

Src: https://stackoverflow.com/questions/71359019/where-to-place-dockerignore-for-docker-build-f-path-to-docker-dockerfile

Right now if you run the following command:

`docker build -t epic-stack:latest -f other/Dockerfile .`

the patterns in `.dockerignore` are in fact not ignored.

In addition, fly allows you to configure the docker and ignorefile in the build section of the configuration which means you don't need to move the files to the root anymore for the honoring of the ignore patterns happening.

Overall, this PR removes unneeded code and workarounds that are better solved with the correct configuration.
