### PR TITLE
chore: remove unused dep @remix-run/serve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
         "@faker-js/faker": "^8.4.1",
         "@playwright/test": "^1.45.2",
         "@remix-run/dev": "2.10.3",
-        "@remix-run/serve": "2.10.3",
         "@remix-run/testing": "2.10.3",
         "@sentry/vite-plugin": "^2.21.1",
         "@sly-cli/sly": "^1.13.0",
@@ -4447,42 +4446,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@remix-run/serve": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.10.3.tgz",
-      "integrity": "sha512-UZyBdob26/e9cECDH4uspDw3xQyZSzHY+iNFVpRO1Iyk1NW1JDW4ImmHGXQSzq4ZKYNLV/ZktLkhY0f91Azt8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/express": "2.10.3",
-        "@remix-run/node": "2.10.3",
-        "chokidar": "^3.5.3",
-        "compression": "^1.7.4",
-        "express": "^4.19.2",
-        "get-port": "5.1.1",
-        "morgan": "^1.10.0",
-        "source-map-support": "^0.5.21"
-      },
-      "bin": {
-        "remix-serve": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@remix-run/serve/node_modules/get-port": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@remix-run/server-runtime": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "@faker-js/faker": "^8.4.1",
     "@playwright/test": "^1.45.2",
     "@remix-run/dev": "2.10.3",
-    "@remix-run/serve": "2.10.3",
     "@remix-run/testing": "2.10.3",
     "@sentry/vite-plugin": "^2.21.1",
     "@sly-cli/sly": "^1.13.0",


### PR DESCRIPTION
While looking at logging solutions for Remix, I naturally checked how Epic Stack was doing it.
I noticed the custom implementation for serving the Remix app in production, and noticed that `@remix-run/serve` was not used, so I removed it.

Let me know if there is a reason that it's still there that I might have missed :) 

## Checklist

- N/A Tests updated
- N/A Docs updated
