### PR TITLE
fix: post converted to get by proxy

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -38,6 +38,8 @@ app.set('trust proxy', true)
 
 // ensure HTTPS only (X-Forwarded-Proto comes from Fly)
 app.use((req, res, next) => {
+	if (req.method !== 'GET') return next()
+	
 	const proto = req.get('X-Forwarded-Proto')
 	const host = getHost(req)
 	if (proto === 'http') {


### PR DESCRIPTION
Fixes #818 , where POST requests get converted to GET requests on certain incoming requests coming from proxy (eg. Botpress)

## Test Plan

- Tested with Botpress to check if the request is received properly.
- Tested the rest of my project to review that everything was working fine.
