### PR TITLE
Save Role seeds between integration tests

### DIFF
--- a/prisma/migrations/20230914194400_init/migration.sql
+++ b/prisma/migrations/20230914194400_init/migration.sql
@@ -173,6 +173,53 @@ CREATE INDEX "_RoleToUser_B_index" ON "_RoleToUser"("B");
 -- Hey there, Kent here! This is how you can reliably seed your database with
 -- some data. You edit the migration.sql file and that will handle it for you.
 
+-- The user Roles and Permissions are seeded here.
+-- If you'd like to customise roles and permissions, you can edit and add the code below to your `prisma/seed.ts` file.
+-- Seed your development database with `npx prisma db seed`
+-- Create a sql dump of your database with `sqlite3 prisma/data.db .dump > seed.sql`
+-- Replace the SQL below with your new Roles & Permissions related SQL from `seed.sql`
+
+-- console.time('🔑 Created permissions...')
+-- const entities = ['user', 'note']
+-- const actions = ['create', 'read', 'update', 'delete']
+-- const accesses = ['own', 'any'] as const
+
+-- let permissionsToCreate = []
+-- for (const entity of entities) {
+-- 	for (const action of actions) {
+-- 		for (const access of accesses) {
+-- 			permissionsToCreate.push({ entity, action, access })
+-- 		}
+-- 	}
+-- }
+-- await prisma.permission.createMany({ data: permissionsToCreate })
+-- console.timeEnd('🔑 Created permissions...')
+
+-- console.time('👑 Created roles...')
+-- await prisma.role.create({
+-- 	data: {
+-- 		name: 'admin',
+-- 		permissions: {
+-- 			connect: await prisma.permission.findMany({
+-- 				select: { id: true },
+-- 				where: { access: 'any' },
+-- 			}),
+-- 		},
+-- 	},
+-- })
+-- await prisma.role.create({
+-- 	data: {
+-- 		name: 'user',
+-- 		permissions: {
+-- 			connect: await prisma.permission.findMany({
+-- 				select: { id: true },
+-- 				where: { access: 'own' },
+-- 			}),
+-- 		},
+-- 	},
+-- })
+-- console.timeEnd('👑 Created roles...')
+
 INSERT INTO Permission VALUES('clnf2zvli0000pcou3zzzzome','create','user','own','',1696625465526,1696625465526);
 INSERT INTO Permission VALUES('clnf2zvll0001pcouly1310ku','create','user','any','',1696625465529,1696625465529);
 INSERT INTO Permission VALUES('clnf2zvll0002pcouka7348re','read','user','own','',1696625465530,1696625465530);

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,12 +3,12 @@ import { promiseHash } from 'remix-utils/promise'
 import { prisma } from '#app/utils/db.server.ts'
 import { MOCK_CODE_GITHUB } from '#app/utils/providers/constants'
 import {
-	cleanupDb,
 	createPassword,
 	createUser,
 	getNoteImages,
 	getUserImages,
 	img,
+	resetDb,
 } from '#tests/db-utils.ts'
 import { insertGitHubUser } from '#tests/mocks/github.ts'
 
@@ -17,49 +17,8 @@ async function seed() {
 	console.time(`🌱 Database has been seeded`)
 
 	console.time('🧹 Cleaned up the database...')
-	await cleanupDb(prisma)
+	await resetDb()
 	console.timeEnd('🧹 Cleaned up the database...')
-
-	console.time('🔑 Created permissions...')
-	const entities = ['user', 'note']
-	const actions = ['create', 'read', 'update', 'delete']
-	const accesses = ['own', 'any'] as const
-
-	let permissionsToCreate = []
-	for (const entity of entities) {
-		for (const action of actions) {
-			for (const access of accesses) {
-				permissionsToCreate.push({ entity, action, access })
-			}
-		}
-	}
-	await prisma.permission.createMany({ data: permissionsToCreate })
-	console.timeEnd('🔑 Created permissions...')
-
-	console.time('👑 Created roles...')
-	await prisma.role.create({
-		data: {
-			name: 'admin',
-			permissions: {
-				connect: await prisma.permission.findMany({
-					select: { id: true },
-					where: { access: 'any' },
-				}),
-			},
-		},
-	})
-	await prisma.role.create({
-		data: {
-			name: 'user',
-			permissions: {
-				connect: await prisma.permission.findMany({
-					select: { id: true },
-					where: { access: 'own' },
-				}),
-			},
-		},
-	})
-	console.timeEnd('👑 Created roles...')
 
 	const totalUsers = 5
 	console.time(`👤 Created ${totalUsers} users...`)

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -130,8 +130,8 @@ export async function cleanupDb(prisma: PrismaClient) {
 		const sql = fs
 			.readFileSync(path)
 			.toString()
-			.split(');')
-			.map((statement) => (statement += ');'))
+			.split(';')
+			.map((statement) => (statement += ';'))
 
 		// Remove empty last line
 		sql.pop()

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker'
 import { type PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
 import { UniqueEnforcer } from 'enforce-unique'
+import { execaCommand } from 'execa'
 
 const uniqueUsernameEnforcer = new UniqueEnforcer()
 
@@ -115,23 +116,17 @@ export async function img({
 	}
 }
 
-export async function cleanupDb(prisma: PrismaClient) {
-	const tables = await prisma.$queryRaw<
-		{ name: string }[]
-	>`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations';`
+export async function resetDb(dbPath?: string) {
+	const databaseUrl = dbPath ? { DATABASE_URL: `file:${dbPath}` } : {}
 
-	try {
-		// Disable FK constraints to avoid relation conflicts during deletion
-		await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = OFF`)
-		await prisma.$transaction([
-			// Delete all rows from each table, preserving table structures
-			...tables.map(({ name }) =>
-				prisma.$executeRawUnsafe(`DELETE from "${name}"`),
-			),
-		])
-	} catch (error) {
-		console.error('Error cleaning up database:', error)
-	} finally {
-		await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = ON`)
-	}
+	await execaCommand(
+		'npx prisma migrate reset --force --skip-seed --skip-generate',
+		{
+			stdio: 'inherit',
+			env: {
+				...process.env,
+				...databaseUrl,
+			},
+		},
+	)
 }

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -115,10 +115,17 @@ export async function img({
 	}
 }
 
-export async function cleanupDb(prisma: PrismaClient) {
-	const tables = await prisma.$queryRaw<
-		{ name: string }[]
-	>`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations';`
+export async function cleanupDb(prisma: PrismaClient, hard = true) {
+	let tables
+	if (hard) {
+		tables = await prisma.$queryRaw<
+			{ name: string }[]
+		>`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations';`
+	} else {
+		tables = await prisma.$queryRaw<
+			{ name: string }[]
+		>`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations' AND name NOT LIKE 'Role' AND name NOT LIKE 'Permission' AND name NOT LIKE '_PermissionToRole';`
+	}
 
 	try {
 		// Disable FK constraints to avoid relation conflicts during deletion

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -120,42 +120,15 @@ export async function cleanupDb(prisma: PrismaClient) {
 		{ name: string }[]
 	>`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations';`
 
-	const migrationPaths = fs
-		.readdirSync('prisma/migrations')
-		.filter((dir) => dir !== 'migration_lock.toml')
-		.map((dir) => `prisma/migrations/${dir}/migration.sql`)
-
-	const migrations = migrationPaths.map((path) => {
-		// Parse the sql into individual statements
-		const sql = fs
-			.readFileSync(path)
-			.toString()
-			.split(';')
-			.map((statement) => (statement += ';'))
-
-		// Remove empty last line
-		sql.pop()
-
-		return sql
-	})
-
 	try {
 		// Disable FK constraints to avoid relation conflicts during deletion
 		await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = OFF`)
 		await prisma.$transaction([
-			// Delete all tables except the ones that are excluded above
+			// Delete all rows from each table, preserving table structures
 			...tables.map(({ name }) =>
-				prisma.$executeRawUnsafe(`DROP TABLE "${name}"`),
+				prisma.$executeRawUnsafe(`DELETE from "${name}"`),
 			),
 		])
-
-		// Run the migrations sequentially
-		for (const migration of migrations) {
-			await prisma.$transaction([
-				// Run each sql statement in the migration
-				...migration.map((sql) => prisma.$executeRawUnsafe(sql)),
-			])
-		}
 	} catch (error) {
 		console.error('Error cleaning up database:', error)
 	} finally {

--- a/tests/setup/db-setup.ts
+++ b/tests/setup/db-setup.ts
@@ -16,7 +16,7 @@ beforeAll(async () => {
 // before prisma is imported and initialized
 afterEach(async () => {
 	const { prisma } = await import('#app/utils/db.server.ts')
-	await cleanupDb(prisma)
+	await cleanupDb(prisma, false)
 })
 
 afterAll(async () => {

--- a/tests/setup/db-setup.ts
+++ b/tests/setup/db-setup.ts
@@ -16,7 +16,7 @@ beforeAll(async () => {
 // before prisma is imported and initialized
 afterEach(async () => {
 	const { prisma } = await import('#app/utils/db.server.ts')
-	await cleanupDb(prisma, false)
+	await cleanupDb(prisma)
 })
 
 afterAll(async () => {

--- a/tests/setup/db-setup.ts
+++ b/tests/setup/db-setup.ts
@@ -11,8 +11,6 @@ beforeAll(async () => {
 	await fsExtra.copyFile(BASE_DATABASE_PATH, databasePath)
 })
 
-// we *must* use dynamic imports here so the process.env.DATABASE_URL is set
-// before prisma is imported and initialized
 afterEach(async () => {
 	await setup()
 })

--- a/tests/setup/db-setup.ts
+++ b/tests/setup/db-setup.ts
@@ -1,8 +1,7 @@
 import path from 'node:path'
 import fsExtra from 'fs-extra'
 import { afterAll, afterEach, beforeAll } from 'vitest'
-import { cleanupDb } from '#tests/db-utils.ts'
-import { BASE_DATABASE_PATH } from './global-setup.ts'
+import { BASE_DATABASE_PATH, setup } from './global-setup.ts'
 
 const databaseFile = `./tests/prisma/data.${process.env.VITEST_POOL_ID || 0}.db`
 const databasePath = path.join(process.cwd(), databaseFile)
@@ -15,8 +14,7 @@ beforeAll(async () => {
 // we *must* use dynamic imports here so the process.env.DATABASE_URL is set
 // before prisma is imported and initialized
 afterEach(async () => {
-	const { prisma } = await import('#app/utils/db.server.ts')
-	await cleanupDb(prisma)
+	await setup()
 })
 
 afterAll(async () => {

--- a/tests/setup/global-setup.ts
+++ b/tests/setup/global-setup.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
-import { execaCommand } from 'execa'
 import fsExtra from 'fs-extra'
+import { resetDb } from '#tests/db-utils.js'
 
 export const BASE_DATABASE_PATH = path.join(
 	process.cwd(),
@@ -22,14 +22,5 @@ export async function setup() {
 		}
 	}
 
-	await execaCommand(
-		'npx prisma migrate reset --force --skip-seed --skip-generate',
-		{
-			stdio: 'inherit',
-			env: {
-				...process.env,
-				DATABASE_URL: `file:${BASE_DATABASE_PATH}`,
-			},
-		},
-	)
+	await resetDb(BASE_DATABASE_PATH)
 }


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
I added a test to `$username.test.tsx` which required a `User` and the user to have a `Role`. The test failed because it couldn't create a new user and connect it to a Role, because there were no longer any Roles in the db.

Upon some deeper digging, I realised that the `Role`, `Permission` and `PermissionToRole` tables that we seed via manual seeds in the init migration, are being wiped between each single test run, due to `cleanupDb()` running in the `afterEach()`.

This means the very first test is able to create a user with a role, but every subsequent test in the file can't.

To resolve this and and enable users with roles to be created in any test, I added a `hard` flag to `cleanupDb()`, to persist the tables above between test runs, if set to `false`.

I tried to do this more elegantly initially, by passing in the exact table names that should be persisted, but I got caught up with trying to interpolate variables into the raw SQL query, which didn't work. (See the source of my struggles [here](https://www.prisma.io/docs/orm/prisma-client/using-raw-sql/raw-queries#considerations))

I resorted to the basic `hard` boolean argument. Please let me know if anyone can see a more elegant way to write this 🙏🏻  

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
