### PR TITLE
fix: serverBuild access in sitemap

### DIFF
--- a/app/routes/_seo+/sitemap[.]xml.ts
+++ b/app/routes/_seo+/sitemap[.]xml.ts
@@ -3,8 +3,8 @@ import { type ServerBuild, type LoaderFunctionArgs } from '@remix-run/node'
 import { getDomainUrl } from '#app/utils/misc.tsx'
 
 export async function loader({ request, context }: LoaderFunctionArgs) {
-	const serverBuild = (await context.serverBuild) as ServerBuild
-	return generateSitemap(request, serverBuild.routes, {
+	const serverBuild = (await context.serverBuild) as { build: ServerBuild }
+	return generateSitemap(request, serverBuild.build.routes, {
 		siteUrl: getDomainUrl(request),
 		headers: {
 			'Cache-Control': `public, max-age=${60 * 5}`,


### PR DESCRIPTION
In `server/index.ts` the returned type of `getBuild` changed. This is to account for the new access to the build routes

closes #844 

<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
