### PR TITLE
no red chalk error

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -110,7 +110,7 @@ export function handleError(
 			true,
 		)
 	} else {
-		console.error(chalk.red(error))
+		console.error(error)
 		Sentry.captureException(error)
 	}
 }


### PR DESCRIPTION
This was causing objects that were thrown to be shown as `[Object object]`. `console.error` should log the error as red anyway.

In our case, there was a sentry error report that was run in a prisma transaction (bad practice, I know), but since there was no active sentry account in the staging environment, this request was timing out (not sure why sentry doesn't throw an error).

The prisma transaction timeout is thrown as an object, not an error instance, and we weren't able to see the error.

All the platforms I tested on (browser, node) output the error in red anyway, so I think it's better just to remove the color to prevent the risk of not showing a proper error message at all.

## Test Plan

I'm not sure this really lends itself to testing

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

Unfortunately I don't have any screenshots, but you can imagine what the `[Object object]` error would look like in the fly logs.