### PR TITLE
Persist Roles and Permissions between test runs

### DIFF
--- a/prisma/migrations/20230914194400_init/migration.sql
+++ b/prisma/migrations/20230914194400_init/migration.sql
@@ -173,6 +173,53 @@ CREATE INDEX "_RoleToUser_B_index" ON "_RoleToUser"("B");
 -- Hey there, Kent here! This is how you can reliably seed your database with
 -- some data. You edit the migration.sql file and that will handle it for you.
 
+-- The user Roles and Permissions are seeded here.
+-- If you'd like to customise roles and permissions, you can edit and add the code below to your `prisma/seed.ts` file.
+-- Seed your development database with `npx prisma db seed`
+-- Create a sql dump of your database with `sqlite3 prisma/data.db .dump > seed.sql`
+-- Replace the SQL below with your new Roles & Permissions related SQL from `seed.sql`
+
+-- console.time('🔑 Created permissions...')
+-- const entities = ['user', 'note']
+-- const actions = ['create', 'read', 'update', 'delete']
+-- const accesses = ['own', 'any'] as const
+
+-- let permissionsToCreate = []
+-- for (const entity of entities) {
+-- 	for (const action of actions) {
+-- 		for (const access of accesses) {
+-- 			permissionsToCreate.push({ entity, action, access })
+-- 		}
+-- 	}
+-- }
+-- await prisma.permission.createMany({ data: permissionsToCreate })
+-- console.timeEnd('🔑 Created permissions...')
+
+-- console.time('👑 Created roles...')
+-- await prisma.role.create({
+-- 	data: {
+-- 		name: 'admin',
+-- 		permissions: {
+-- 			connect: await prisma.permission.findMany({
+-- 				select: { id: true },
+-- 				where: { access: 'any' },
+-- 			}),
+-- 		},
+-- 	},
+-- })
+-- await prisma.role.create({
+-- 	data: {
+-- 		name: 'user',
+-- 		permissions: {
+-- 			connect: await prisma.permission.findMany({
+-- 				select: { id: true },
+-- 				where: { access: 'own' },
+-- 			}),
+-- 		},
+-- 	},
+-- })
+-- console.timeEnd('👑 Created roles...')
+
 INSERT INTO Permission VALUES('clnf2zvli0000pcou3zzzzome','create','user','own','',1696625465526,1696625465526);
 INSERT INTO Permission VALUES('clnf2zvll0001pcouly1310ku','create','user','any','',1696625465529,1696625465529);
 INSERT INTO Permission VALUES('clnf2zvll0002pcouka7348re','read','user','own','',1696625465530,1696625465530);

--- a/prisma/migrations/20230914194400_init/migration.sql
+++ b/prisma/migrations/20230914194400_init/migration.sql
@@ -256,4 +256,3 @@ INSERT INTO _PermissionToRole VALUES('clnf2zvlp0008pcou9r0fhbm8','clnf2zvlx000hp
 INSERT INTO _PermissionToRole VALUES('clnf2zvlq000apcouxnspejs9','clnf2zvlx000hpcou5dfrbegs');
 INSERT INTO _PermissionToRole VALUES('clnf2zvlr000cpcouy1vp6oeg','clnf2zvlx000hpcou5dfrbegs');
 INSERT INTO _PermissionToRole VALUES('clnf2zvls000epcou4ts5ui8f','clnf2zvlx000hpcou5dfrbegs');
-

--- a/prisma/migrations/20230914194400_init/migration.sql
+++ b/prisma/migrations/20230914194400_init/migration.sql
@@ -256,3 +256,4 @@ INSERT INTO _PermissionToRole VALUES('clnf2zvlp0008pcou9r0fhbm8','clnf2zvlx000hp
 INSERT INTO _PermissionToRole VALUES('clnf2zvlq000apcouxnspejs9','clnf2zvlx000hpcou5dfrbegs');
 INSERT INTO _PermissionToRole VALUES('clnf2zvlr000cpcouy1vp6oeg','clnf2zvlx000hpcou5dfrbegs');
 INSERT INTO _PermissionToRole VALUES('clnf2zvls000epcou4ts5ui8f','clnf2zvlx000hpcou5dfrbegs');
+

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,12 +3,12 @@ import { promiseHash } from 'remix-utils/promise'
 import { prisma } from '#app/utils/db.server.ts'
 import { MOCK_CODE_GITHUB } from '#app/utils/providers/constants'
 import {
+	cleanupDb,
 	createPassword,
 	createUser,
 	getNoteImages,
 	getUserImages,
 	img,
-	resetDb,
 } from '#tests/db-utils.ts'
 import { insertGitHubUser } from '#tests/mocks/github.ts'
 
@@ -17,7 +17,7 @@ async function seed() {
 	console.time(`🌱 Database has been seeded`)
 
 	console.time('🧹 Cleaned up the database...')
-	await resetDb()
+	await cleanupDb(prisma)
 	console.timeEnd('🧹 Cleaned up the database...')
 
 	const totalUsers = 5

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,12 +3,12 @@ import { promiseHash } from 'remix-utils/promise'
 import { prisma } from '#app/utils/db.server.ts'
 import { MOCK_CODE_GITHUB } from '#app/utils/providers/constants'
 import {
-	cleanupDb,
 	createPassword,
 	createUser,
 	getNoteImages,
 	getUserImages,
 	img,
+	resetDb,
 } from '#tests/db-utils.ts'
 import { insertGitHubUser } from '#tests/mocks/github.ts'
 
@@ -17,49 +17,8 @@ async function seed() {
 	console.time(`🌱 Database has been seeded`)
 
 	console.time('🧹 Cleaned up the database...')
-	await cleanupDb(prisma)
+	await resetDb()
 	console.timeEnd('🧹 Cleaned up the database...')
-
-	console.time('🔑 Created permissions...')
-	const entities = ['user', 'note']
-	const actions = ['create', 'read', 'update', 'delete']
-	const accesses = ['own', 'any'] as const
-
-	let permissionsToCreate = []
-	for (const entity of entities) {
-		for (const action of actions) {
-			for (const access of accesses) {
-				permissionsToCreate.push({ entity, action, access })
-			}
-		}
-	}
-	await prisma.permission.createMany({ data: permissionsToCreate })
-	console.timeEnd('🔑 Created permissions...')
-
-	console.time('👑 Created roles...')
-	await prisma.role.create({
-		data: {
-			name: 'admin',
-			permissions: {
-				connect: await prisma.permission.findMany({
-					select: { id: true },
-					where: { access: 'any' },
-				}),
-			},
-		},
-	})
-	await prisma.role.create({
-		data: {
-			name: 'user',
-			permissions: {
-				connect: await prisma.permission.findMany({
-					select: { id: true },
-					where: { access: 'own' },
-				}),
-			},
-		},
-	})
-	console.timeEnd('👑 Created roles...')
 
 	const totalUsers = 5
 	console.time(`👤 Created ${totalUsers} users...`)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,7 +17,7 @@ async function seed() {
 	console.time(`🌱 Database has been seeded`)
 
 	console.time('🧹 Cleaned up the database...')
-	await cleanupDb(prisma)
+	await cleanupDb()
 	console.timeEnd('🧹 Cleaned up the database...')
 
 	const totalUsers = 5

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs'
 import { faker } from '@faker-js/faker'
-import { type PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
 import Database from 'better-sqlite3'
 import { UniqueEnforcer } from 'enforce-unique'

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -147,8 +147,8 @@ export async function cleanupDb(prisma: PrismaClient) {
 				try {
 					await prisma.$executeRawUnsafe(`${statement};`)
 				} catch (error) {
-					console.warn(`Failed to execute statement: ${statement}`, error)
-					// Continue with the next statement
+					console.warn(`Failed to execute statement: ${statement}`)
+					throw error
 				}
 			}
 		}

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -147,8 +147,7 @@ export async function cleanupDb(prisma: PrismaClient) {
 				try {
 					await prisma.$executeRawUnsafe(`${statement};`)
 				} catch (error) {
-					console.warn(`Failed to execute statement: ${statement}`)
-					throw error
+					console.error(`Failed to execute statement: ${statement}`, error)
 				}
 			}
 		}

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -144,8 +144,6 @@ export async function cleanupDb(prisma: PrismaClient) {
 				.map((statement) => statement.trim())
 				.filter(Boolean)
 
-			//trigger CI
-
 			// Run each sql statement in the migration
 			await prisma.$transaction(
 				[

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -144,6 +144,8 @@ export async function cleanupDb(prisma: PrismaClient) {
 				.map((statement) => statement.trim())
 				.filter(Boolean)
 
+			//trigger CI
+
 			// Run each sql statement in the migration
 			await prisma.$transaction(
 				[

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -120,15 +120,42 @@ export async function cleanupDb(prisma: PrismaClient) {
 		{ name: string }[]
 	>`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations';`
 
+	const migrationPaths = fs
+		.readdirSync('prisma/migrations')
+		.filter((dir) => dir !== 'migration_lock.toml')
+		.map((dir) => `prisma/migrations/${dir}/migration.sql`)
+
+	const migrations = migrationPaths.map((path) => {
+		// Parse the sql into individual statements
+		const sql = fs
+			.readFileSync(path)
+			.toString()
+			.split(';')
+			.map((statement) => (statement += ';'))
+
+		// Remove empty last line
+		sql.pop()
+
+		return sql
+	})
+
 	try {
 		// Disable FK constraints to avoid relation conflicts during deletion
 		await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = OFF`)
 		await prisma.$transaction([
-			// Delete all rows from each table, preserving table structures
+			// Delete all tables except the ones that are excluded above
 			...tables.map(({ name }) =>
-				prisma.$executeRawUnsafe(`DELETE from "${name}"`),
+				prisma.$executeRawUnsafe(`DROP TABLE "${name}"`),
 			),
 		])
+
+		// Run the migrations sequentially
+		for (const migration of migrations) {
+			await prisma.$transaction([
+				// Run each sql statement in the migration
+				...migration.map((sql) => prisma.$executeRawUnsafe(sql)),
+			])
+		}
 	} catch (error) {
 		console.error('Error cleaning up database:', error)
 	} finally {

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -149,6 +149,7 @@ export async function cleanupDb(prisma: PrismaClient) {
 				} catch (error) {
 					//trigger CI rerun
 					console.error(`Failed to execute statement: ${statement}`, error)
+					throw error
 				}
 			}
 		}

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -147,16 +147,11 @@ export async function cleanupDb(prisma: PrismaClient) {
 			//trigger
 
 			// Run each sql statement in the migration
-			await prisma.$transaction(
-				[
-					...statements.map((statement) =>
-						prisma.$executeRawUnsafe(`${statement}`),
-					),
-				],
-				{
-					isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-				},
-			)
+			await prisma.$transaction([
+				...statements.map((statement) =>
+					prisma.$executeRawUnsafe(`${statement}`),
+				),
+			])
 		}
 	} catch (error) {
 		console.error('Error cleaning up database:', error)

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -145,7 +145,6 @@ export async function cleanupDb(prisma: PrismaClient) {
 			// Run each sql statement in the migration
 			for (const statement of statements) {
 				try {
-					//trigger CI
 					await prisma.$executeRawUnsafe(`${statement};`)
 				} catch (error) {
 					console.warn(`Failed to execute statement: ${statement}`)

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -147,7 +147,6 @@ export async function cleanupDb(prisma: PrismaClient) {
 				try {
 					await prisma.$executeRawUnsafe(`${statement};`)
 				} catch (error) {
-					//trigger CI rerun
 					console.error(`Failed to execute statement: ${statement}`, error)
 					throw error
 				}

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -147,6 +147,7 @@ export async function cleanupDb(prisma: PrismaClient) {
 				try {
 					await prisma.$executeRawUnsafe(`${statement};`)
 				} catch (error) {
+					//trigger CI rerun
 					console.error(`Failed to execute statement: ${statement}`, error)
 				}
 			}

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import { faker } from '@faker-js/faker'
-import { Prisma, type PrismaClient } from '@prisma/client'
+import { type PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
 import { UniqueEnforcer } from 'enforce-unique'
 
@@ -143,8 +143,6 @@ export async function cleanupDb(prisma: PrismaClient) {
 				.split(';')
 				.map((statement) => statement.trim())
 				.filter(Boolean)
-
-			//trigger
 
 			// Run each sql statement in the migration
 			await prisma.$transaction([

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -143,14 +143,16 @@ export async function cleanupDb(prisma: PrismaClient) {
 				.filter(Boolean)
 
 			// Run each sql statement in the migration
-			for (const statement of statements) {
-				try {
-					await prisma.$executeRawUnsafe(`${statement};`)
-				} catch (error) {
-					console.warn(`Failed to execute statement: ${statement}`)
-					throw error
+			await prisma.$transaction(async (tx) => {
+				for (const statement of statements) {
+					try {
+						await tx.$executeRawUnsafe(`${statement}`)
+					} catch (error) {
+						console.warn(`Failed to execute statement: ${statement}`)
+						throw error
+					}
 				}
-			}
+			})
 		}
 	} catch (error) {
 		console.error('Error cleaning up database:', error)

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import { faker } from '@faker-js/faker'
-import { type PrismaClient } from '@prisma/client'
+import { Prisma, type PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
 import { UniqueEnforcer } from 'enforce-unique'
 
@@ -145,11 +145,16 @@ export async function cleanupDb(prisma: PrismaClient) {
 				.filter(Boolean)
 
 			// Run each sql statement in the migration
-			await prisma.$transaction([
-				...statements.map((statement) =>
-					prisma.$executeRawUnsafe(`${statement}`),
-				),
-			])
+			await prisma.$transaction(
+				[
+					...statements.map((statement) =>
+						prisma.$executeRawUnsafe(`${statement}`),
+					),
+				],
+				{
+					isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+				},
+			)
 		}
 	} catch (error) {
 		console.error('Error cleaning up database:', error)

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -131,10 +131,9 @@ export async function cleanupDb(prisma: PrismaClient) {
 			.readFileSync(path)
 			.toString()
 			.split(';')
-			.map((statement) => (statement += ';'))
-
-		// Remove empty last line
-		sql.pop()
+			.map(statement => statement.trim())
+			.filter(Boolean)
+			.map((statement) => `${statement};`))
 
 		return sql
 	})

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -147,7 +147,7 @@ export async function cleanupDb(prisma: PrismaClient) {
 				try {
 					await prisma.$executeRawUnsafe(`${statement};`)
 				} catch (error) {
-					console.error(`Failed to execute statement: ${statement}`, error)
+					console.warn(`Failed to execute statement: ${statement}`)
 					throw error
 				}
 			}

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -144,6 +144,8 @@ export async function cleanupDb(prisma: PrismaClient) {
 				.map((statement) => statement.trim())
 				.filter(Boolean)
 
+			//trigger
+
 			// Run each sql statement in the migration
 			await prisma.$transaction(
 				[

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -131,9 +131,9 @@ export async function cleanupDb(prisma: PrismaClient) {
 			.readFileSync(path)
 			.toString()
 			.split(';')
-			.map(statement => statement.trim())
+			.map((statement) => statement.trim())
 			.filter(Boolean)
-			.map((statement) => `${statement};`))
+			.map((statement) => `${statement};`)
 
 		return sql
 	})

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -1,9 +1,8 @@
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import { faker } from '@faker-js/faker'
-import { type PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
 import { UniqueEnforcer } from 'enforce-unique'
-import { execaCommand } from 'execa'
 
 const uniqueUsernameEnforcer = new UniqueEnforcer()
 
@@ -119,10 +118,10 @@ export async function img({
 export async function resetDb(dbPath?: string) {
 	const databaseUrl = dbPath ? { DATABASE_URL: `file:${dbPath}` } : {}
 
-	await execaCommand(
-		'npx prisma migrate reset --force --skip-seed --skip-generate',
+	spawnSync(
+		'npx',
+		['prisma', 'migrate', 'reset', '--force', '--skip-seed', '--skip-generate'],
 		{
-			stdio: 'inherit',
 			env: {
 				...process.env,
 				...databaseUrl,

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -147,6 +147,7 @@ export async function cleanupDb(prisma: PrismaClient) {
 				try {
 					await prisma.$executeRawUnsafe(`${statement};`)
 				} catch (error) {
+					//trigger CI rerun
 					console.error(`Failed to execute statement: ${statement}`, error)
 					throw error
 				}

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -145,6 +145,7 @@ export async function cleanupDb(prisma: PrismaClient) {
 			// Run each sql statement in the migration
 			for (const statement of statements) {
 				try {
+					//trigger CI
 					await prisma.$executeRawUnsafe(`${statement};`)
 				} catch (error) {
 					console.warn(`Failed to execute statement: ${statement}`)

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker'
 import { type PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
 import { UniqueEnforcer } from 'enforce-unique'
+import { execaCommand } from 'execa'
 
 const uniqueUsernameEnforcer = new UniqueEnforcer()
 
@@ -115,50 +116,17 @@ export async function img({
 	}
 }
 
-export async function cleanupDb(prisma: PrismaClient) {
-	const tables = await prisma.$queryRaw<
-		{ name: string }[]
-	>`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations';`
+export async function resetDb(dbPath?: string) {
+	const databaseUrl = dbPath ? { DATABASE_URL: `file:${dbPath}` } : {}
 
-	const migrationPaths = fs
-		.readdirSync('prisma/migrations')
-		.filter((dir) => dir !== 'migration_lock.toml')
-		.map((dir) => `prisma/migrations/${dir}/migration.sql`)
-
-	const migrations = migrationPaths.map((path) => {
-		// Parse the sql into individual statements
-		const sql = fs
-			.readFileSync(path)
-			.toString()
-			.split(';')
-			.map((statement) => (statement += ';'))
-
-		// Remove empty last line
-		sql.pop()
-
-		return sql
-	})
-
-	try {
-		// Disable FK constraints to avoid relation conflicts during deletion
-		await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = OFF`)
-		await prisma.$transaction([
-			// Delete all tables except the ones that are excluded above
-			...tables.map(({ name }) =>
-				prisma.$executeRawUnsafe(`DROP TABLE "${name}"`),
-			),
-		])
-
-		// Run the migrations sequentially
-		for (const migration of migrations) {
-			await prisma.$transaction([
-				// Run each sql statement in the migration
-				...migration.map((sql) => prisma.$executeRawUnsafe(sql)),
-			])
-		}
-	} catch (error) {
-		console.error('Error cleaning up database:', error)
-	} finally {
-		await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = ON`)
-	}
+	await execaCommand(
+		'npx prisma migrate reset --force --skip-seed --skip-generate',
+		{
+			stdio: 'inherit',
+			env: {
+				...process.env,
+				...databaseUrl,
+			},
+		},
+	)
 }

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import { faker } from '@faker-js/faker'
 import { type PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
+import Database from 'better-sqlite3'
 import { UniqueEnforcer } from 'enforce-unique'
 
 const uniqueUsernameEnforcer = new UniqueEnforcer()
@@ -115,45 +116,63 @@ export async function img({
 	}
 }
 
-export async function cleanupDb(prisma: PrismaClient) {
-	const tables = await prisma.$queryRaw<
-		{ name: string }[]
-	>`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations';`
+let _migrationSqls: Array<Array<string>> | undefined
+async function getMigrationSqls() {
+	if (_migrationSqls) return _migrationSqls
+
+	const migrationSqls: Array<Array<string>> = []
+	const migrationPaths = (await fs.promises.readdir('prisma/migrations'))
+		.filter((dir) => dir !== 'migration_lock.toml')
+		.map((dir) => `prisma/migrations/${dir}/migration.sql`)
+
+	for (const path of migrationPaths) {
+		const sql = await fs.promises.readFile(path, 'utf8')
+		const statements = sql
+			.split(';')
+			.map((statement) => statement.trim())
+			.filter(Boolean)
+		migrationSqls.push(statements)
+	}
+
+	_migrationSqls = migrationSqls
+
+	return migrationSqls
+}
+
+export async function cleanupDb() {
+	const db = new Database(process.env.DATABASE_URL!.replace('file:', ''))
 
 	try {
 		// Disable FK constraints to avoid relation conflicts during deletion
-		await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = OFF`)
+		db.exec('PRAGMA foreign_keys = OFF')
+
+		// Get all table names
+		const tables = db
+			.prepare(
+				`
+			SELECT name FROM sqlite_master 
+			WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations'
+		`,
+			)
+			.all() as { name: string }[]
 
 		// Delete tables except the ones that are excluded above
-		await prisma.$transaction([
-			...tables.map(({ name }) =>
-				prisma.$executeRawUnsafe(`DROP TABLE IF EXISTS "${name}"`),
-			),
-		])
-
-		const migrationPaths = fs
-			.readdirSync('prisma/migrations')
-			.filter((dir) => dir !== 'migration_lock.toml')
-			.map((dir) => `prisma/migrations/${dir}/migration.sql`)
-
-		// Run each migration
-		for (const path of migrationPaths) {
-			const sql = fs.readFileSync(path, 'utf8')
-			const statements = sql
-				.split(';')
-				.map((statement) => statement.trim())
-				.filter(Boolean)
-
-			// Run each sql statement in the migration
-			await prisma.$transaction([
-				...statements.map((statement) =>
-					prisma.$executeRawUnsafe(`${statement}`),
-				),
-			])
+		for (const { name } of tables) {
+			db.exec(`DROP TABLE IF EXISTS "${name}"`)
 		}
-	} catch (error) {
-		console.error('Error cleaning up database:', error)
+
+		// Get migration SQLs and run each migration
+		const migrationSqls = await getMigrationSqls()
+		for (const statements of migrationSqls) {
+			// Run each sql statement in the migration
+			db.transaction(() => {
+				for (const statement of statements) {
+					db.exec(statement)
+				}
+			})()
+		}
 	} finally {
-		await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = ON`)
+		db.exec('PRAGMA foreign_keys = ON')
+		db.close()
 	}
 }

--- a/tests/setup/db-setup.ts
+++ b/tests/setup/db-setup.ts
@@ -1,8 +1,7 @@
 import path from 'node:path'
 import fsExtra from 'fs-extra'
 import { afterAll, afterEach, beforeAll } from 'vitest'
-import { cleanupDb } from '#tests/db-utils.ts'
-import { BASE_DATABASE_PATH } from './global-setup.ts'
+import { BASE_DATABASE_PATH, setup } from './global-setup.ts'
 
 const databaseFile = `./tests/prisma/data.${process.env.VITEST_POOL_ID || 0}.db`
 const databasePath = path.join(process.cwd(), databaseFile)
@@ -12,11 +11,8 @@ beforeAll(async () => {
 	await fsExtra.copyFile(BASE_DATABASE_PATH, databasePath)
 })
 
-// we *must* use dynamic imports here so the process.env.DATABASE_URL is set
-// before prisma is imported and initialized
 afterEach(async () => {
-	const { prisma } = await import('#app/utils/db.server.ts')
-	await cleanupDb(prisma)
+	await setup()
 })
 
 afterAll(async () => {

--- a/tests/setup/db-setup.ts
+++ b/tests/setup/db-setup.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import fsExtra from 'fs-extra'
 import { afterAll, afterEach, beforeAll } from 'vitest'
-import { resetDb } from '#tests/db-utils.js'
+import { cleanupDb } from '#tests/db-utils.ts'
 import { BASE_DATABASE_PATH } from './global-setup.ts'
 
 const databaseFile = `./tests/prisma/data.${process.env.VITEST_POOL_ID || 0}.db`
@@ -12,8 +12,11 @@ beforeAll(async () => {
 	await fsExtra.copyFile(BASE_DATABASE_PATH, databasePath)
 })
 
+// we *must* use dynamic imports here so the process.env.DATABASE_URL is set
+// before prisma is imported and initialized
 afterEach(async () => {
-	await resetDb()
+	const { prisma } = await import('#app/utils/db.server.ts')
+	await cleanupDb(prisma)
 })
 
 afterAll(async () => {

--- a/tests/setup/db-setup.ts
+++ b/tests/setup/db-setup.ts
@@ -1,7 +1,8 @@
 import path from 'node:path'
 import fsExtra from 'fs-extra'
 import { afterAll, afterEach, beforeAll } from 'vitest'
-import { BASE_DATABASE_PATH, setup } from './global-setup.ts'
+import { resetDb } from '#tests/db-utils.js'
+import { BASE_DATABASE_PATH } from './global-setup.ts'
 
 const databaseFile = `./tests/prisma/data.${process.env.VITEST_POOL_ID || 0}.db`
 const databasePath = path.join(process.cwd(), databaseFile)
@@ -12,7 +13,7 @@ beforeAll(async () => {
 })
 
 afterEach(async () => {
-	await setup()
+	await resetDb()
 })
 
 afterAll(async () => {

--- a/tests/setup/db-setup.ts
+++ b/tests/setup/db-setup.ts
@@ -15,8 +15,7 @@ beforeAll(async () => {
 // we *must* use dynamic imports here so the process.env.DATABASE_URL is set
 // before prisma is imported and initialized
 afterEach(async () => {
-	const { prisma } = await import('#app/utils/db.server.ts')
-	await cleanupDb(prisma)
+	await cleanupDb()
 })
 
 afterAll(async () => {

--- a/tests/setup/global-setup.ts
+++ b/tests/setup/global-setup.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
+import { execaCommand } from 'execa'
 import fsExtra from 'fs-extra'
-import { resetDb } from '#tests/db-utils.js'
 
 export const BASE_DATABASE_PATH = path.join(
 	process.cwd(),
@@ -22,5 +22,14 @@ export async function setup() {
 		}
 	}
 
-	await resetDb(BASE_DATABASE_PATH)
+	await execaCommand(
+		'npx prisma migrate reset --force --skip-seed --skip-generate',
+		{
+			stdio: 'inherit',
+			env: {
+				...process.env,
+				DATABASE_URL: `file:${BASE_DATABASE_PATH}`,
+			},
+		},
+	)
 }

--- a/tests/setup/global-setup.ts
+++ b/tests/setup/global-setup.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
-import { execaCommand } from 'execa'
 import fsExtra from 'fs-extra'
+import { resetDb } from '#tests/db-utils.js'
 
 export const BASE_DATABASE_PATH = path.join(
 	process.cwd(),
@@ -22,14 +22,5 @@ export async function setup() {
 		}
 	}
 
-	await execaCommand(
-		'npx prisma migrate reset --force --skip-seed --skip-generate',
-		{
-			stdio: 'inherit',
-			env: {
-				...process.env,
-				DATABASE_URL: `file:${BASE_DATABASE_PATH}`,
-			},
-		},
-	)
+	await resetDb(BASE_DATABASE_PATH)
 }


### PR DESCRIPTION
# Problem
Roles and Permissions are cleared from the db after the first test run, so we are not able to create Users in subsequent tests.

# Solution
Ensure Roles and Permissions are persisted between tests.

# Approaches considered
## A. Exclude Roles & Permissions tables from being dropped
We can explicitly exclude the `Role`, `Permission` and `_PermissionToRole` tables from being dropped between tests, by updating the SQL in `cleanupDb()`.

This option is viable. 

The downside of this approach is that if a user changes these tables in their schema, they will also need to know to update the `cleanupDb` function. It may be nicer to avoid these extra touch points.

## B. Use prisma migrate reset
We attempted to use prisma's built in migration command - `npx prisma migrate reset --force --skip-seed --skip-generate'`.

The issue with this approach, is that we use `execa` to run this command, which needs to be run in a `node` environment, and some of our tests run in the `jsdom` vitest environment.

Because of this constraint, this option doesn't seem viable. A or C may be better options.

## C. Use a custom reset script (used in this PR)
Instead of `prisma migrate reset`, we can manually drop all tables and run every migration by loading and running the SQL.

One potential downside of this approach is the complexity of importing, parsing and running each individual SQL statement from each migration file. We are using `;` as the delimiter, which could break if any data in the SQL statment has this character anywhere except at the end of each SQL statement, but this isn't an issue right now. 

An upside of this is that it doesn't add any extra touch points like we do in option A.

This is the approach used in this PR.
