### PR TITLE
Catch errors that cause shutdowns and send them to Sentry

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,14 +18,6 @@ sourceMapSupport.install({
 	},
 })
 
-closeWithGrace(async ({ err }) => {
-	if (err) {
-		console.error(chalk.red(err))
-		console.error(chalk.red(err.stack))
-		process.exit(1)
-	}
-})
-
 if (process.env.MOCKS === 'true') {
 	await import('./tests/mocks/index.ts')
 }


### PR DESCRIPTION
- Fixes #872 

Before this PR, epic-stack has two calls to close-with-grace. This removes the redundant call, which was usually the one that ran first and prevented the other one from running. It then adds integration with Sentry so that errors that cause the server to shut down are sent to Sentry, and we give Sentry 500 milliseconds to flush any other errors that haven't been sent yet.