### PR TITLE
Fix issue#806 - page jump caused by h-screen on wrapping div

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -214,7 +214,7 @@ function App() {
 
 	return (
 		<>
-			<div className="flex h-screen flex-col justify-between">
+			<div className="flex min-h-screen flex-col justify-between">
 				<header className="container py-6">
 					<nav className="flex flex-wrap items-center justify-between gap-4 sm:flex-nowrap md:gap-8">
 						<Logo />


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
Fixes issue #806 

h-screen limits the height of the wrapping div to screen size. Changing to min-h-screen applies a minimum height as should be the case for a wrapping div like this.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/27907b90-b073-490d-bc1a-db8e14c29068)

After:
![image](https://github.com/user-attachments/assets/39af6cb4-2dce-4152-9637-bf83eee0d0e9)


<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
