### PR TITLE
remove glob for source maps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,5 @@
 import { vitePlugin as remix } from '@remix-run/dev'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
-import { glob } from 'glob'
 import { flatRoutes } from 'remix-flat-routes'
 import { envOnlyMacros } from 'vite-env-only'
 import { type ViteUserConfig } from 'vitest/config'
@@ -79,10 +78,10 @@ export default {
 						},
 					},
 					sourcemaps: {
-						filesToDeleteAfterUpload: await glob([
+						filesToDeleteAfterUpload: [
 							'./build/**/*.map',
 							'.server-build/**/*.map',
-						]),
+						],
 					},
 				})
 			: null,


### PR DESCRIPTION
sentry already uses a glob, and if you glob before generating the source maps, they will not be deleted, because they did not exist at the time of the glob

## Test Plan
We tested on our server
