### PR TITLE
handle not found post requests

### DIFF
--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -9,7 +9,11 @@ import { Link, useLocation } from '@remix-run/react'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
 import { Icon } from '#app/components/ui/icon.tsx'
 
-export async function loader() {
+export function loader() {
+	throw new Response('Not found', { status: 404 })
+}
+
+export function action() {
 	throw new Response('Not found', { status: 404 })
 }
 


### PR DESCRIPTION
not found post requests creates noice on sentry:
```You made a POST request to "/some/path" but did not provide an `action` for route "routes/$", so there is no way to handle the request.```


## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
