### PR TITLE
Updated deprecated property

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -144,7 +144,7 @@ const maxMultiple =
 	!IS_PROD || process.env.PLAYWRIGHT_TEST_BASE_URL ? 10_000 : 1
 const rateLimitDefault = {
 	windowMs: 60 * 1000,
-    limit: 1000 * maxMultiple,
+	 limit: 1000 * maxMultiple,
 	standardHeaders: true,
 	legacyHeaders: false,
 	validate: { trustProxy: false },

--- a/server/index.ts
+++ b/server/index.ts
@@ -144,7 +144,7 @@ const maxMultiple =
 	!IS_PROD || process.env.PLAYWRIGHT_TEST_BASE_URL ? 10_000 : 1
 const rateLimitDefault = {
 	windowMs: 60 * 1000,
-	max: 1000 * maxMultiple,
+    limit: 1000 * maxMultiple,
 	standardHeaders: true,
 	legacyHeaders: false,
 	validate: { trustProxy: false },
@@ -160,13 +160,13 @@ const rateLimitDefault = {
 const strongestRateLimit = rateLimit({
 	...rateLimitDefault,
 	windowMs: 60 * 1000,
-	max: 10 * maxMultiple,
+	limit: 10 * maxMultiple,
 })
 
 const strongRateLimit = rateLimit({
 	...rateLimitDefault,
 	windowMs: 60 * 1000,
-	max: 100 * maxMultiple,
+    limit: 100 * maxMultiple,
 })
 
 const generalRateLimit = rateLimit(rateLimitDefault)

--- a/server/index.ts
+++ b/server/index.ts
@@ -166,7 +166,7 @@ const strongestRateLimit = rateLimit({
 const strongRateLimit = rateLimit({
 	...rateLimitDefault,
 	windowMs: 60 * 1000,
-    limit: 100 * maxMultiple,
+	 limit: 100 * maxMultiple,
 })
 
 const generalRateLimit = rateLimit(rateLimitDefault)


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
The `max` property of the `express-rate-limit` package has been deprecated as of September 12, 2023, in favor of `limit`.
[https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.0.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v7.0.0)
> The limit configuration option is now preferred to max.
It still shows the same behavior, and max is still supported. The change was made to better align with terminology used in the IETF standard drafts.
## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated
