### PR TITLE
change sentry import to correct package

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -30,10 +30,12 @@ env var during runtime:
 fly secrets set SENTRY_DSN=<your_dsn>
 ```
 
-See the guide for the remix
-[here](https://docs.sentry.io/platforms/javascript/guides/remix/). Run the
-installation wizard but note that some of the steps included already exist in
-this codebase so be sure to remove any duplication.
+See the guides for React Router v7
+[here(library)](https://docs.sentry.io/platforms/javascript/guides/react/features/react-router/v7/)
+and
+[here(framwork)](https://docs.sentry.io/platforms/javascript/guides/react-router/).
+Note that the dedicated SDK for React Router is under development and features
+are lacking.
 
 To generate the auth token, click
 [this](https://sentry.io/orgredirect/settings/:orgslug/developer-settings/new-internal/)

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto'
 import { createRequestHandler } from '@react-router/express'
-import * as Sentry from '@sentry/react'
+import * as Sentry from '@sentry/node'
 import { ip as ipAddress } from 'address'
 import chalk from 'chalk'
 import closeWithGrace from 'close-with-grace'
@@ -144,7 +144,7 @@ const maxMultiple =
 	!IS_PROD || process.env.PLAYWRIGHT_TEST_BASE_URL ? 10_000 : 1
 const rateLimitDefault = {
 	windowMs: 60 * 1000,
-	 limit: 1000 * maxMultiple,
+	limit: 1000 * maxMultiple,
 	standardHeaders: true,
 	legacyHeaders: false,
 	validate: { trustProxy: false },
@@ -166,7 +166,7 @@ const strongestRateLimit = rateLimit({
 const strongRateLimit = rateLimit({
 	...rateLimitDefault,
 	windowMs: 60 * 1000,
-	 limit: 100 * maxMultiple,
+	limit: 100 * maxMultiple,
 })
 
 const generalRateLimit = rateLimit(rateLimitDefault)

--- a/server/utils/monitoring.ts
+++ b/server/utils/monitoring.ts
@@ -1,6 +1,5 @@
-import { prismaIntegration, httpIntegration } from '@sentry/node'
+import * as Sentry from '@sentry/node'
 import { nodeProfilingIntegration } from '@sentry/profiling-node'
-import * as Sentry from '@sentry/react'
 
 export function init() {
 	Sentry.init({
@@ -18,8 +17,8 @@ export function init() {
 			/\/site\.webmanifest/,
 		],
 		integrations: [
-			prismaIntegration(),
-			httpIntegration(),
+			Sentry.prismaIntegration(),
+			Sentry.httpIntegration(),
 			nodeProfilingIntegration(),
 		],
 		tracesSampler(samplingContext) {


### PR DESCRIPTION
These are server-side setup and should use `@sentry/node` instead of `@sentry/react`.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
