### PR TITLE
Add react router generated types folder to remix.init/gitignore

### DIFF
--- a/remix.init/gitignore
+++ b/remix.init/gitignore
@@ -24,3 +24,6 @@ node_modules
 
 # generated files
 /app/components/ui/icons
+
+# react router v7 generated types
+.react-router


### PR DESCRIPTION
I think we miss this when migrating to React Router v7