### PR TITLE
sentry don't capture response

### DIFF
--- a/app/components/error-boundary.tsx
+++ b/app/components/error-boundary.tsx
@@ -28,18 +28,23 @@ export function GeneralErrorBoundary({
 }) {
 	const error = useRouteError()
 	const params = useParams()
+	const isResponse = isRouteErrorResponse(error)
 
 	if (typeof document !== 'undefined') {
 		console.error(error)
 	}
 
 	useEffect(() => {
+		if (isResponse) {
+			return
+		}
+
 		captureException(error)
-	}, [error])
+	}, [error, isResponse])
 
 	return (
 		<div className="container flex items-center justify-center p-20 text-h2">
-			{isRouteErrorResponse(error)
+			{isResponse
 				? (statusHandlers?.[error.status] ?? defaultStatusHandler)({
 						error,
 						params,

--- a/app/components/error-boundary.tsx
+++ b/app/components/error-boundary.tsx
@@ -35,9 +35,7 @@ export function GeneralErrorBoundary({
 	}
 
 	useEffect(() => {
-		if (isResponse) {
-			return
-		}
+		if (isResponse) return
 
 		captureException(error)
 	}, [error, isResponse])


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
I got this from sentry:
```
Error: Object captured as exception with keys: data, internal, status, statusText
```

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
