### PR TITLE
fix: remove unused allowIndexing prop

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -143,7 +143,6 @@ function Document({
 	nonce: string
 	theme?: Theme
 	env?: Record<string, string | undefined>
-	allowIndexing?: boolean
 }) {
 	const allowIndexing = ENV.ALLOW_INDEXING !== 'false'
 	return (


### PR DESCRIPTION
<!-- Summary: Put your summary here -->

Since `allowIndexing` now comes from an env variable, this prop is not used and can be safely removed

## Test Plan

Call to `<Document nonce={nonce} theme={theme} env={data?.ENV}>` does not complain