### PR TITLE
refactor: simplified session query by removing redundant user join

### DIFF
--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -30,17 +30,17 @@ export async function getUserId(request: Request) {
 	const sessionId = authSession.get(sessionKey)
 	if (!sessionId) return null
 	const session = await prisma.session.findUnique({
-		select: { user: { select: { id: true } } },
+		select: { userId: true },
 		where: { id: sessionId, expirationDate: { gt: new Date() } },
 	})
-	if (!session?.user) {
+	if (!session?.userId) {
 		throw redirect('/', {
 			headers: {
 				'set-cookie': await authSessionStorage.destroySession(authSession),
 			},
 		})
 	}
-	return session.user.id
+	return session.userId
 }
 
 export async function requireUserId(


### PR DESCRIPTION
The current session query joins with the User table to get the userId, 
which is unnecessary since we can directly select userId from the Session table. 
Since we have onDelete: Cascade constraint, the database already guarantees 
referential integrity, making the join redundant.

- Removes unnecessary table join
- Improves query performance
- Relies on database constraints for data integrity