### PR TITLE
fix: add missing name for query parameter redirectTo

### DIFF
--- a/app/routes/_auth+/login.tsx
+++ b/app/routes/_auth+/login.tsx
@@ -181,7 +181,7 @@ export default function LoginPage({ actionData }: Route.ComponentProps) {
 							<Link
 								to={
 									redirectTo
-										? `/signup?${encodeURIComponent(redirectTo)}`
+										? `/signup?redirectTo=${encodeURIComponent(redirectTo)}`
 										: '/signup'
 								}
 							>


### PR DESCRIPTION
This PR fixes the malformed signup redirect URL by adding the missing redirectTo query parameter when a redirectTo value is present. This ensures that the redirect works correctly and includes the parameter name in the URL.

## Test Plan

No tests or docs need changing

This should fix #925 