### PR TITLE
[chore] update Tigris URLs to use tigrisdata.com

### DIFF
--- a/docs/decisions/040-tigris-image-storage.md
+++ b/docs/decisions/040-tigris-image-storage.md
@@ -63,5 +63,5 @@ The implementation involves:
 
 ## References
 
-- [Tigris Documentation](https://www.tigris.com/docs)
+- [Tigris Documentation](https://www.tigrisdata.com/docs)
 - Previous image handling: [018-images.md](docs/decisions/018-images.md)

--- a/docs/image-storage.md
+++ b/docs/image-storage.md
@@ -1,6 +1,6 @@
 # Image Storage
 
-The Epic Stack uses [Tigris](https://www.tigris.com), an S3-compatible object
+The Epic Stack uses [Tigris](https://www.tigrisdata.com), an S3-compatible object
 storage service, for storing and serving uploaded images. Tigris is integrated
 tightly with Fly.io, so you don't need to worry about setting up an account or
 configuring any credentials.


### PR DESCRIPTION
The [tigris.com](https://tigris.com/) website is currently unreachable. The [tigrisdata.com](https://www.tigrisdata.com/) works fine.

## Test Plan

* You can try to visit the [tigris.com](https://tigris.com/) website.

## Checklist

- [ ] Tests updated
- [x] Docs updated

## Screenshots

**Links before**

_Main page_
![tigris com](https://github.com/user-attachments/assets/d72dac94-27b4-4319-8d2d-9652c3a31c8c)

**Links after**

_Main page_
![tigrisdata com](https://github.com/user-attachments/assets/5b7bffea-c3ee-406b-9dbd-e2c4c34b7d43)

_Docs page_
![tigrisdata com:docs](https://github.com/user-attachments/assets/b724b6d4-f9e3-4ae8-ad0b-e9a00af40bdb)

