### PR TITLE
add explicit key prop to JSX element

### DIFF
--- a/app/routes/users+/$username_+/__note-editor.tsx
+++ b/app/routes/users+/$username_+/__note-editor.tsx
@@ -184,7 +184,7 @@ function ImageChooser({
 	const [altText, setAltText] = useState(fields.altText.initialValue ?? '')
 
 	return (
-		<fieldset {...getFieldsetProps(meta)}>
+		<fieldset {...getFieldsetProps(meta)} key={meta.id}>
 			<div className="flex gap-3">
 				<div className="w-32">
 					<div className="relative h-32 w-32">
@@ -225,7 +225,10 @@ function ImageChooser({
 								</div>
 							)}
 							{existingImage ? (
-								<input {...getInputProps(fields.id, { type: 'hidden' })} />
+								<input
+									{...getInputProps(fields.id, { type: 'hidden' })}
+									key={fields.id.id}
+								/>
 							) : null}
 							<input
 								aria-label="Image"
@@ -245,6 +248,7 @@ function ImageChooser({
 								}}
 								accept="image/*"
 								{...getInputProps(fields.file, { type: 'file' })}
+								key={fields.file.id}
 							/>
 						</label>
 					</div>
@@ -257,6 +261,7 @@ function ImageChooser({
 					<Textarea
 						onChange={(e) => setAltText(e.currentTarget.value)}
 						{...getTextareaProps(fields.altText)}
+						key={fields.altText.id}
 					/>
 					<div className="min-h-[32px] px-4 pb-3 pt-1">
 						<ErrorList


### PR DESCRIPTION
[Please check Issue](https://github.com/epicweb-dev/epic-stack/issues/953)

## Test Plan

On a new epic stack instance, visit and click the new note page visiting `/users/:username/notes/new` and the browser console should be empty with errors:

![image](https://github.com/user-attachments/assets/c62dc051-341b-4528-ae5e-7550bbbd7f21)


## Checklist

- [ ] Tests updated: No
- [ ] Docs updated: No

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->

Before (when creating a new note)

![image](https://github.com/user-attachments/assets/7f1a0d23-28dc-48fe-b612-0b6a245f7b0e)

After:

![image](https://github.com/user-attachments/assets/f9c00b47-4e6a-4240-ad68-168a1a1c8fe6)

