### PR TITLE
Update openimg to v0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "lru-cache": "^11.0.2",
         "mime-types": "^2.1.35",
         "morgan": "^1.10.0",
-        "openimg": "^0.5.1",
+        "openimg": "^0.6.0",
         "prisma": "^6.4.1",
         "qrcode": "^1.5.4",
         "react": "^19.0.0",
@@ -12566,9 +12566,9 @@
       }
     },
     "node_modules/openimg": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/openimg/-/openimg-0.5.1.tgz",
-      "integrity": "sha512-9g62sqsWz9kCqGjOqUwaYfOsEmrw/YaVlgcai1+nSldDz2gWkfDWfozdoPY8og5AeUirO9QPzvvW1gCfD3aUPw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/openimg/-/openimg-0.6.0.tgz",
+      "integrity": "sha512-9Ak4aw0vSGzpG6zfTN0rYk34VG6oSWPsJg75eoIEMG6EU8nce2Nf+0EU3yhAW3pe2SlrBQRAnh/EpjGV5+L1bg==",
       "license": "MIT",
       "optionalDependencies": {
         "react": ">=18.0.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "lru-cache": "^11.0.2",
     "mime-types": "^2.1.35",
     "morgan": "^1.10.0",
-    "openimg": "^0.5.1",
+    "openimg": "^0.6.0",
     "prisma": "^6.4.1",
     "qrcode": "^1.5.4",
     "react": "^19.0.0",


### PR DESCRIPTION
Update openimg to v0.6

## Details

The new version of openimg now correctly includes the `content-type` and `content-length` headers in all cases. This ensures that saved images always have the correct file extension attached by the browser. The update also adds a `metadata.json` file to the cache if you want to check that out!

## Background

I don't want to load the image into memory at once but stream it. However, that makes retrieving the image metadata tricky. The source of truth is sharp, but retrieving the metadata of an image from sharp while streaming it directly out to the client is tricky. HTTP headers must be set before the body starts streaming, but sharp needs to process parts of the image before the metadata is available. I was finally able to figure this out with a `PassThrough` stream that buffers chunks until the metadata is available and only then starts streaming it out to the client ([relevant changes here](https://github.com/andrelandgraf/openimg/commit/503a29afeb1eaf6b1427a8a2e97b0e89b60f16ca#diff-85d98bb2f320277f480fb3604957babfecd948fef483dee74428fd8a36828935R120)). A new `metadata.json` file now stores image metadata for cached files. This is inspired by [mjackson's local-file-storage](https://github.com/mjackson/remix-the-web/blob/main/packages/file-storage/src/lib/local-file-storage.ts)! I tested it out on allthingsweb, and things seem to work. :)

### Before

Added `jpeg` extension to image on download even though real content-type was png.

![Screenshot 2025-03-01 at 11 41 09 PM](https://github.com/user-attachments/assets/422360c7-aa63-48db-b718-b38f1e15b419)

### After

![Screenshot 2025-03-01 at 11 42 25 PM](https://github.com/user-attachments/assets/b458780a-613b-40f6-8f30-f30c646119e5)

## Test Plan

- Download user profile data as JSON
- Click on image link in JSON data
- Download/save image from browser
- Verify that the correct file extension is added
