### PR TITLE
fix: clearing profile name

### DIFF
--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -23,7 +23,7 @@ export const handle: SEOHandle = {
 }
 
 const ProfileFormSchema = z.object({
-	name: NameSchema.optional(),
+	name: NameSchema.nullable().default(null),
 	username: UsernameSchema,
 })
 


### PR DESCRIPTION
Currently submitting an empty name on `/settings/profile` does not get persisted to the database. 

This happens due to empty string being coerced to undefined by conform and prisma treating undefined values  the same as the value not being provided at all.

Not sure if  there is some establish pattern for this. I'm guessing even people using zod and prisma without conform would like to avoid mixing "" and null for optional data.