### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ cp .env.example .env
 npm install
 
 # setup database
-prisma migrate reset --force
+npx prisma migrate reset --force
 
 # Install playwright browsers
 npm run test:e2e:install


### PR DESCRIPTION
Fixes the contributing guidelines that imply that `prisma` CLI is globally installed. Uses `npx prisma` to use the same version of Prisma provided with Epic Stack. Generally, installing node modules globally is a bad idea and should be avoided.

<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [x] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
