### PR TITLE
hide sourcemap references in build output

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig((config) => ({
 			}
 		},
 
-		sourcemap: true,
+		sourcemap: 'hidden',
 	},
 	server: {
 		watch: {


### PR DESCRIPTION
## Problem

When a webpage is loaded with DevTools open, the browser automatically attempts to fetch `.map` files if a sourceMappingURL comment is present at the end of each JavaScript file.
```js
//# sourceMappingURL=xxx.js.map
```

Vite includes this comment by default when `build.sourcemap` is set to `true`.
In our case, sourcemaps are removed after the build process by the Sentry plugin, so these requests result in a large number of 404s and can cause performance issues.

## Solution

Set `build.sourcemap` to `'hidden'` in `vite.config.ts`.
https://vite.dev/config/build-options.html#build-sourcemap

This ensures that sourcemaps are still generated, but the sourceMappingURL comment is no longer injected into the final JS output — preventing unnecessary network requests triggered by DevTools.