### PR TITLE
Pr/fix image preview reuse

### DIFF
--- a/app/routes/users+/$username_+/__note-editor.tsx
+++ b/app/routes/users+/$username_+/__note-editor.tsx
@@ -225,7 +225,10 @@ function ImageChooser({
 								</div>
 							)}
 							{existingImage ? (
-								<input {...getInputProps(fields.id, { type: 'hidden' })} />
+								<input
+									{...getInputProps(fields.id, { type: 'hidden' })}
+									key={fields.id.key}
+								/>
 							) : null}
 							<input
 								aria-label="Image"
@@ -245,6 +248,7 @@ function ImageChooser({
 								}}
 								accept="image/*"
 								{...getInputProps(fields.file, { type: 'file' })}
+								key={fields.file.key}
 							/>
 						</label>
 					</div>
@@ -257,6 +261,7 @@ function ImageChooser({
 					<Textarea
 						onChange={(e) => setAltText(e.currentTarget.value)}
 						{...getTextareaProps(fields.altText)}
+						key={fields.altText.key}
 					/>
 					<div className="min-h-[32px] px-4 pt-1 pb-3">
 						<ErrorList

--- a/app/routes/users+/$username_+/__note-editor.tsx
+++ b/app/routes/users+/$username_+/__note-editor.tsx
@@ -110,7 +110,10 @@ export function NoteEditor({
 							<Label>Images</Label>
 							<ul className="flex flex-col gap-4">
 								{imageList.map((imageMeta, index) => {
-									const image = note?.images[index]
+									const imageMetaId = imageMeta.getFieldset().id.value
+									const image = note?.images.find(
+										({ id }) => id === imageMetaId,
+									)
 									return (
 										<li
 											key={imageMeta.key}


### PR DESCRIPTION
Fix the reuse of existing note images as preview when images are deleted and new images are being added.

## Test Plan

Testing locally in epic-stack fork and personal project that uses the same logic.

## Checklist

- [ ] Tests updated
- [ ] Docs updated

No tests or documentation updates necessary

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
