### PR TITLE
Fix reuse of existing image as new image preview

### DIFF
--- a/app/routes/users+/$username_+/__note-editor.tsx
+++ b/app/routes/users+/$username_+/__note-editor.tsx
@@ -110,7 +110,10 @@ export function NoteEditor({
 							<Label>Images</Label>
 							<ul className="flex flex-col gap-4">
 								{imageList.map((imageMeta, index) => {
-									const image = note?.images[index]
+									const imageMetaId = imageMeta.getFieldset().id.value
+									const image = note?.images.find(
+										({ id }) => id === imageMetaId,
+									)
 									return (
 										<li
 											key={imageMeta.key}


### PR DESCRIPTION
Fix the reuse of existing note images as preview when images are deleted and new images are being added.

## Test Plan

Testing locally in epic-stack fork and personal project that uses the same logic.

## Checklist

- [ ] Tests updated
- [ ] Docs updated

No tests or documentation updates necessary

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
