### PR TITLE
upload source maps during build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,6 +184,7 @@ jobs:
             --push \
             --image-label ${{ github.sha }} \
             --build-arg COMMIT_SHA=${{ github.sha }} \
+            --build-secret SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
             --app ${{ steps.app_name.outputs.value }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
@@ -213,16 +214,16 @@ jobs:
       - name: 🚀 Deploy Staging
         if: ${{ github.ref == 'refs/heads/dev' }}
         run: |
-          IMAGE="registry.fly.io/${{ steps.app_name.outputs.value }}-staging:${{ github.sha }}"
-          flyctl deploy --image $IMAGE --app ${{ steps.app_name.outputs.value }}-staging
+          flyctl deploy \
+            --image "registry.fly.io/${{ steps.app_name.outputs.value }}-staging:${{ github.sha }}" \
+            --app ${{ steps.app_name.outputs.value }}-staging
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: 🚀 Deploy Production
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          IMAGE="registry.fly.io/${{ steps.app_name.outputs.value }}:${{ github.sha }}"
-          flyctl deploy --image $IMAGE \
-            --build-secret SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+          flyctl deploy \
+            --image "registry.fly.io/${{ steps.app_name.outputs.value }}:${{ github.sha }}"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
Now that the image is built in the `Build Container` step instead of the `Deploy` step, we need to include the sentry auth token in the `Build Container` step. 

## Test Plan

I have tested this in production on our server. The source map is uploaded to sentry and referenced by a hash of the file, so you can upload as many source maps as you want, and they will not interfere with the source map in production.


## Screenshots

### Before

<img width="544" alt="Screenshot 2025-05-15 at 10 13 03 AM" src="https://github.com/user-attachments/assets/2b4a7b48-f593-4fc1-97e5-5cc79b35eff8" />

### After

<img width="683" alt="Screenshot 2025-05-22 at 3 37 12 PM" src="https://github.com/user-attachments/assets/bc31b8bc-b659-4393-9607-a62890424862" />
