### PR TITLE
fix the existing note image replacement

### DIFF
--- a/app/routes/users+/$username_+/__note-editor.tsx
+++ b/app/routes/users+/$username_+/__note-editor.tsx
@@ -201,7 +201,7 @@ function ImageChooser({
 						>
 							{previewImage ? (
 								<div className="relative">
-									{existingImage ? (
+									{existingImage && !previewImage.startsWith('data:') ? (
 										<Img
 											src={previewImage}
 											alt={altText ?? ''}


### PR DESCRIPTION
Fixes the incorrect usage of the `<Img>` component when `previewImage` was a data URL during existing note image replacement.

<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
