### PR TITLE
test: add type-safe `navigate` utility

### DIFF
--- a/tests/e2e/2fa.test.ts
+++ b/tests/e2e/2fa.test.ts
@@ -4,11 +4,12 @@ import { expect, test } from '#tests/playwright-utils.ts'
 
 test('Users can add 2FA to their account and use it when logging in', async ({
 	page,
+	navigate,
 	login,
 }) => {
 	const password = faker.internet.password()
 	const user = await login({ password })
-	await page.goto('/settings/profile')
+	await navigate('/settings/profile')
 
 	await page.getByRole('link', { name: /enable 2fa/i }).click()
 
@@ -40,7 +41,7 @@ test('Users can add 2FA to their account and use it when logging in', async ({
 	await page.getByRole('menuitem', { name: /logout/i }).click()
 	await expect(page).toHaveURL(`/`)
 
-	await page.goto('/login')
+	await navigate('/login')
 	await expect(page).toHaveURL(`/login`)
 	await page.getByRole('textbox', { name: /username/i }).fill(user.username)
 	await page.getByLabel(/^password$/i).fill(password)

--- a/tests/e2e/error-boundary.test.ts
+++ b/tests/e2e/error-boundary.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '#tests/playwright-utils.ts'
 
-test('Test root error boundary caught', async ({ page }) => {
+test('Test root error boundary caught', async ({ page, navigate }) => {
 	const pageUrl = '/does-not-exist'
-	const res = await page.goto(pageUrl)
+	const res = await navigate(pageUrl as any)
 
 	expect(res?.status()).toBe(404)
 	await expect(page.getByText(/We can't find this page/i)).toBeVisible()

--- a/tests/e2e/note-images.test.ts
+++ b/tests/e2e/note-images.test.ts
@@ -3,9 +3,13 @@ import { type NoteImage, type Note } from '@prisma/client'
 import { prisma } from '#app/utils/db.server.ts'
 import { expect, test } from '#tests/playwright-utils.ts'
 
-test('Users can create note with an image', async ({ page, login }) => {
+test('Users can create note with an image', async ({
+	page,
+	navigate,
+	login,
+}) => {
 	const user = await login()
-	await page.goto(`/users/${user.username}/notes`)
+	await navigate('/users/:username/notes', { username: user.username })
 
 	const newNote = createNote()
 	const altText = 'cute koala'
@@ -28,9 +32,13 @@ test('Users can create note with an image', async ({ page, login }) => {
 	).toBeVisible()
 })
 
-test('Users can create note with multiple images', async ({ page, login }) => {
+test('Users can create note with multiple images', async ({
+	page,
+	navigate,
+	login,
+}) => {
 	const user = await login()
-	await page.goto(`/users/${user.username}/notes`)
+	await navigate('/users/:username/notes', { username: user.username })
 
 	const newNote = createNote()
 	const altText1 = 'cute koala'
@@ -60,7 +68,7 @@ test('Users can create note with multiple images', async ({ page, login }) => {
 	await expect(page.getByAltText(altText2)).toBeVisible()
 })
 
-test('Users can edit note image', async ({ page, login }) => {
+test('Users can edit note image', async ({ page, navigate, login }) => {
 	const user = await login()
 
 	const note = await prisma.note.create({
@@ -70,7 +78,10 @@ test('Users can edit note image', async ({ page, login }) => {
 			ownerId: user.id,
 		},
 	})
-	await page.goto(`/users/${user.username}/notes/${note.id}`)
+	await navigate('/users/:username/notes/:noteId', {
+		username: user.username,
+		noteId: note.id,
+	})
 
 	// edit the image
 	await page.getByRole('link', { name: 'Edit', exact: true }).click()
@@ -86,7 +97,7 @@ test('Users can edit note image', async ({ page, login }) => {
 	await expect(page.getByAltText(updatedImage.altText)).toBeVisible()
 })
 
-test('Users can delete note image', async ({ page, login }) => {
+test('Users can delete note image', async ({ page, navigate, login }) => {
 	const user = await login()
 
 	const note = await prisma.note.create({
@@ -96,7 +107,10 @@ test('Users can delete note image', async ({ page, login }) => {
 			ownerId: user.id,
 		},
 	})
-	await page.goto(`/users/${user.username}/notes/${note.id}`)
+	await navigate('/users/:username/notes/:noteId', {
+		username: user.username,
+		noteId: note.id,
+	})
 
 	await expect(page.getByRole('heading', { name: note.title })).toBeVisible()
 	const images = page
@@ -118,6 +132,7 @@ function createNote() {
 		content: faker.lorem.paragraphs(3),
 	} satisfies Omit<Note, 'id' | 'createdAt' | 'updatedAt' | 'type' | 'ownerId'>
 }
+
 function createNoteWithImage() {
 	return {
 		...createNote(),

--- a/tests/e2e/notes.test.ts
+++ b/tests/e2e/notes.test.ts
@@ -2,9 +2,9 @@ import { faker } from '@faker-js/faker'
 import { prisma } from '#app/utils/db.server.ts'
 import { expect, test } from '#tests/playwright-utils.ts'
 
-test('Users can create notes', async ({ page, login }) => {
+test('Users can create notes', async ({ page, navigate, login }) => {
 	const user = await login()
-	await page.goto(`/users/${user.username}/notes`)
+	await navigate('/users/:username/notes', { username: user.username })
 
 	const newNote = createNote()
 	await page.getByRole('link', { name: /New Note/i }).click()
@@ -17,14 +17,17 @@ test('Users can create notes', async ({ page, login }) => {
 	await expect(page).toHaveURL(new RegExp(`/users/${user.username}/notes/.*`))
 })
 
-test('Users can edit notes', async ({ page, login }) => {
+test('Users can edit notes', async ({ page, navigate, login }) => {
 	const user = await login()
 
 	const note = await prisma.note.create({
 		select: { id: true },
 		data: { ...createNote(), ownerId: user.id },
 	})
-	await page.goto(`/users/${user.username}/notes/${note.id}`)
+	await navigate('/users/:username/notes/:noteId', {
+		username: user.username,
+		noteId: note.id,
+	})
 
 	// edit the note
 	await page.getByRole('link', { name: 'Edit', exact: true }).click()
@@ -41,14 +44,17 @@ test('Users can edit notes', async ({ page, login }) => {
 	).toBeVisible()
 })
 
-test('Users can delete notes', async ({ page, login }) => {
+test('Users can delete notes', async ({ page, navigate, login }) => {
 	const user = await login()
 
 	const note = await prisma.note.create({
 		select: { id: true },
 		data: { ...createNote(), ownerId: user.id },
 	})
-	await page.goto(`/users/${user.username}/notes/${note.id}`)
+	await navigate('/users/:username/notes/:noteId', {
+		username: user.username,
+		noteId: note.id,
+	})
 
 	// find links with href prefix
 	const noteLinks = page

--- a/tests/e2e/passkey.test.ts
+++ b/tests/e2e/passkey.test.ts
@@ -18,7 +18,11 @@ async function setupWebAuthn(page: any) {
 	return { client, authenticatorId: result.authenticatorId }
 }
 
-test('Users can register and use passkeys', async ({ page, login }) => {
+test('Users can register and use passkeys', async ({
+	page,
+	navigate,
+	login,
+}) => {
 	const user = await login()
 
 	const { client, authenticatorId } = await setupWebAuthn(page)
@@ -31,7 +35,7 @@ test('Users can register and use passkeys', async ({ page, login }) => {
 		'No credentials should exist initially',
 	).toHaveLength(0)
 
-	await page.goto('/settings/profile/passkeys')
+	await navigate('/settings/profile/passkeys')
 
 	const passkeyRegisteredPromise = new Promise<void>((resolve) => {
 		client.once('WebAuthn.credentialAdded', () => resolve())
@@ -58,8 +62,8 @@ test('Users can register and use passkeys', async ({ page, login }) => {
 	await expect(page).toHaveURL(`/`)
 
 	// Try logging in with passkey
-	await page.goto('/login')
-	const signCount1 = afterRegistrationCredentials.credentials[0].signCount
+	await navigate('/login')
+	const signCount1 = afterRegistrationCredentials.credentials[0]!.signCount
 
 	const passkeyAssertedPromise = new Promise<void>((resolve) => {
 		client.once('WebAuthn.credentialAsserted', () => resolve())
@@ -85,12 +89,12 @@ test('Users can register and use passkeys', async ({ page, login }) => {
 		authenticatorId,
 	})
 	expect(afterLoginCredentials.credentials).toHaveLength(1)
-	expect(afterLoginCredentials.credentials[0].signCount).toBeGreaterThan(
+	expect(afterLoginCredentials.credentials[0]?.signCount).toBeGreaterThan(
 		signCount1,
 	)
 
 	// Go to passkeys page and delete the passkey
-	await page.goto('/settings/profile/passkeys')
+	await navigate('/settings/profile/passkeys')
 	await page.getByRole('button', { name: /delete/i }).click()
 
 	// Verify the passkey is no longer listed on the page
@@ -109,7 +113,7 @@ test('Users can register and use passkeys', async ({ page, login }) => {
 	await expect(page).toHaveURL(`/`)
 
 	// Try logging in with the deleted passkey
-	await page.goto('/login')
+	await navigate('/login')
 	const deletedPasskeyAssertedPromise = new Promise<void>((resolve) => {
 		client.once('WebAuthn.credentialAsserted', () => resolve())
 	})
@@ -125,11 +129,15 @@ test('Users can register and use passkeys', async ({ page, login }) => {
 	await expect(page).toHaveURL(`/login`)
 })
 
-test('Failed passkey verification shows error', async ({ page, login }) => {
+test('Failed passkey verification shows error', async ({
+	page,
+	navigate,
+	login,
+}) => {
 	const password = faker.internet.password()
 	await login({ password })
 	const { client, authenticatorId } = await setupWebAuthn(page)
-	await page.goto('/settings/profile/passkeys')
+	await navigate('/settings/profile/passkeys')
 
 	// Try to register with failed verification
 	await client.send('WebAuthn.setUserVerified', {

--- a/tests/e2e/search.test.ts
+++ b/tests/e2e/search.test.ts
@@ -1,9 +1,9 @@
 import { invariant } from '@epic-web/invariant'
 import { expect, test } from '#tests/playwright-utils.ts'
 
-test('Search from home page', async ({ page, insertNewUser }) => {
+test('Search from home page', async ({ page, navigate, insertNewUser }) => {
 	const newUser = await insertNewUser()
-	await page.goto('/')
+	await navigate('/')
 
 	await page.getByRole('searchbox', { name: /search/i }).fill(newUser.username)
 	await page.getByRole('button', { name: /search/i }).click()

--- a/tests/e2e/settings-profile.test.ts
+++ b/tests/e2e/settings-profile.test.ts
@@ -7,9 +7,9 @@ import { expect, test, createUser, waitFor } from '#tests/playwright-utils.ts'
 
 const CODE_REGEX = /Here's your verification code: (?<code>[\d\w]+)/
 
-test('Users can update their basic info', async ({ page, login }) => {
+test('Users can update their basic info', async ({ page, navigate, login }) => {
 	await login()
-	await page.goto('/settings/profile')
+	await navigate('/settings/profile')
 
 	const newUserData = createUser()
 
@@ -21,11 +21,11 @@ test('Users can update their basic info', async ({ page, login }) => {
 	await page.getByRole('button', { name: /^save/i }).click()
 })
 
-test('Users can update their password', async ({ page, login }) => {
+test('Users can update their password', async ({ page, navigate, login }) => {
 	const oldPassword = faker.internet.password()
 	const newPassword = faker.internet.password()
 	const user = await login({ password: oldPassword })
-	await page.goto('/settings/profile')
+	await navigate('/settings/profile')
 
 	await page.getByRole('link', { name: /change password/i }).click()
 
@@ -52,9 +52,13 @@ test('Users can update their password', async ({ page, login }) => {
 	).toEqual({ id: user.id })
 })
 
-test('Users can update their profile photo', async ({ page, login }) => {
+test('Users can update their profile photo', async ({
+	page,
+	navigate,
+	login,
+}) => {
 	const user = await login()
-	await page.goto('/settings/profile')
+	await navigate('/settings/profile')
 
 	const beforeSrc = await page
 		.getByRole('main')
@@ -86,11 +90,15 @@ test('Users can update their profile photo', async ({ page, login }) => {
 	expect(beforeSrc).not.toEqual(afterSrc)
 })
 
-test('Users can change their email address', async ({ page, login }) => {
+test('Users can change their email address', async ({
+	page,
+	navigate,
+	login,
+}) => {
 	const preUpdateUser = await login()
 	const newEmailAddress = faker.internet.email().toLowerCase()
 	expect(preUpdateUser.email).not.toEqual(newEmailAddress)
-	await page.goto('/settings/profile')
+	await navigate('/settings/profile')
 	await page.getByRole('link', { name: /change email/i }).click()
 	await page.getByRole('textbox', { name: /new email/i }).fill(newEmailAddress)
 	await page.getByRole('button', { name: /send confirmation/i }).click()

--- a/tests/playwright-utils.ts
+++ b/tests/playwright-utils.ts
@@ -1,5 +1,6 @@
-import { test as base } from '@playwright/test'
+import { test as base, type Response } from '@playwright/test'
 import { type User as UserModel } from '@prisma/client'
+import { href, type Register } from 'react-router'
 import * as setCookieParser from 'set-cookie-parser'
 import {
 	getPasswordHash,
@@ -63,11 +64,21 @@ async function getOrInsertUser({
 	}
 }
 
+export type AppPages = keyof Register['pages']
+
 export const test = base.extend<{
+	navigate: <Path extends AppPages>(
+		...args: Parameters<typeof href<Path>>
+	) => Promise<null | Response>
 	insertNewUser(options?: GetOrInsertUserOptions): Promise<User>
 	login(options?: GetOrInsertUserOptions): Promise<User>
 	prepareGitHubUser(): Promise<GitHubUser>
 }>({
+	navigate: async ({ page }, use) => {
+		await use((...args) => {
+			return page.goto(href(...args))
+		})
+	},
 	insertNewUser: async ({}, use) => {
 		let userId: string | undefined = undefined
 		await use(async (options) => {


### PR DESCRIPTION
<!-- Summary: Put your summary here -->

I'm adding a new Playwright fixture called `navigate()`. The purpose of this fixture is to provide type-safe navigation experience in tests by inferring the available page URLs from `react-router`'s codegen. This means less mechanical mistakes when testing your app.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

Verified by updating the existing E2E test suite and seeing it passing.

## Checklist

- [x] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->

<img width="2584" height="594" alt="Screenshot 2025-08-25 at 10 58 18" src="https://github.com/user-attachments/assets/a503f1e9-bba1-4351-961c-c246e3ab9379" />

## Brainstorming

### Why not override the default `page.goto()`?

TL;DR `navigate()` is a higher-level abstraction over `page.goto()`, _not_ its replacement.

1. To allow visiting external websites.
2. Because `page.goto()` has a different call signature (i.e. custom `options` argument).

### How to ensure `navigate()` usage over `page.goto()`?

You don't. As I mentioned above, the two are not equivalent and aren't meant to be used interchangeably. Our job is to show the best practices of type-safe navigation in tests, then it's the developer's job to adhere to them. 

### How to navigate to a dynamically generated URL?

Throughout the test suite, there are cases when the navigation target is created dynamically, e.g. extracted from the "Forgot password" email text. In those cases, the best course of action is to _type cast_ the extracted URL to be of the most permissive type:

```ts
import { type AppPages } from '#tests/playwright-utils.ts'
const resetPasswordUrl = extractUrl(email.text) as AppPages
await navigate(resetPasswordUrl)
```

> By doing this, you are saying "I expect this dynamic URL to be one of my app's URLs", which is an even more type-safe way to approach such URLs in tests.

### How to provide `page.goto()` options, like `waitUntil`?

Ideally, don't. `navigate()` is an opinionated wrapper that provisions the same navigation behavior. Keep in mind that some options, like `waitUntil`, are being deprecated by Playwright themselves in favor of more deterministic state await mechanisms (i.e. don't wait until network is idle, add an assertion over what UI state to expect). 

We can expand the `navigate()` utility in the future if there's a need to pass other navigation options. For now, I believe it works sufficiently. 