### PR TITLE
fix: improve accessibility of the user menu

### DIFF
--- a/app/components/user-dropdown.tsx
+++ b/app/components/user-dropdown.tsx
@@ -25,6 +25,7 @@ export function UserDropdown() {
 						// this is for progressive enhancement
 						onClick={(e) => e.preventDefault()}
 						className="flex items-center gap-2"
+						aria-label="User menu"
 					>
 						<Img
 							className="size-8 rounded-full object-cover"
@@ -32,6 +33,7 @@ export function UserDropdown() {
 							src={getUserImgSrc(user.image?.objectKey)}
 							width={256}
 							height={256}
+							aria-hidden="true"
 						/>
 						<span className="text-body-sm font-bold">
 							{user.name ?? user.username}


### PR DESCRIPTION
<!-- Summary: Put your summary here -->

When testing the Epic Stack app as a part of my recent workshop, I've noticed that certain UI elements have poor accessibility, which resulted in them being rather difficult to properly target during the tests. 

The user menu dropdown is one such example. Right now, it has an accessible name comprised of the username repeated twice:

<img width="3898" height="2512" alt="Screenshot 2025-08-25 at 11 24 18" src="https://github.com/user-attachments/assets/1f742733-6eda-4475-8a4d-d843de1d7c9d" />

This happens because the dropdown has two elements, each of which has user's username as the accessible text:

- the avatar `img` as `alt={user.name}`
- the dropdown button content is `user.name`.

That results into the element's accessible test being "Kody Kody", which looks broken.

Instead, the element's accessible text should describe what that element is or does. In this case, I propose it should be something like "User menu".

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
