### PR TITLE
fix: prevent user avatar from shrinking

### DIFF
--- a/app/routes/users+/$username_+/notes.tsx
+++ b/app/routes/users+/$username_+/notes.tsx
@@ -38,12 +38,12 @@ export default function NotesRoute({ loaderData }: Route.ComponentProps) {
 					<div className="absolute inset-0 flex flex-col">
 						<Link
 							to={`/users/${loaderData.owner.username}`}
-							className="bg-muted flex flex-col items-center justify-center gap-2 pt-12 pr-4 pb-4 pl-8 lg:flex-row lg:justify-start lg:gap-4"
+							className="bg-muted flex flex-col items-center justify-center gap-2 pt-12 pr-4 pb-4 pl-8 xl:flex-row xl:justify-start xl:gap-4"
 						>
 							<Img
 								src={getUserImgSrc(loaderData.owner.image?.objectKey)}
 								alt={ownerDisplayName}
-								className="size-16 rounded-full object-cover lg:h-24 lg:w-24"
+								className="size-16 rounded-full object-cover xl:size-24"
 								width={256}
 								height={256}
 							/>


### PR DESCRIPTION
<!-- Summary: Put your summary here -->

The user avatar element on the `/users/:username/notes` page _shrinks_, resulting in a broken UI:

<img width="2060" height="1578" alt="Screenshot 2025-08-25 at 12 13 41" src="https://github.com/user-attachments/assets/3c9fd867-a021-42cf-a2c2-0f48ca5ef2a1" />

This is even more apparent with a placeholder avatar:

<img width="544" height="352" alt="Screenshot 2025-07-14 at 10 25 21" src="https://github.com/user-attachments/assets/755f9937-70bd-4702-b75f-f5026b37e20d" />

This happens because the `Link` parent has `display: flex` and the text content (the user name) takes priority when it grows, shrinking the image.

Now, traditionally, you fix this by setting `flex-shrink: 0` on the element whose dimensions you wish to preserve. Alas, the component tree of the `Img` component doesn't make that fix possible as the classes you provide to the component end up on the `<img />` element and not the parent `<picture />` element, which is the child of the flex container:

```
<Link>
  <picture> // <- shrink-0 needs to go here
    <img> // <- but it ends up going here
```

As such, I'm proposing the next best thing, which is to _fallback to the next responsive state of this element sooner_:

<img width="2516" height="732" alt="Screenshot 2025-08-25 at 12 18 33" src="https://github.com/user-attachments/assets/60989368-6e44-4775-b733-86e703b2ff1e" />

This makes the avatar/username wrap sooner, preventing the shrunk avatar issue.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
