### PR TITLE
Add seed database command to getting started doc

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,6 +45,12 @@ set SKIP_SETUP=true && set SKIP_FORMAT=true && set SKIP_DEPLOYMENT=true && npx e
   npm run setup
   ```
 
+- Seed database:
+
+  ```sh
+  npx prisma db seed
+  ```
+
 - Start dev server:
 
   ```sh


### PR DESCRIPTION
Developer is unable to login with user `kody` after setting up project following [Getting started docs](https://github.com/epicweb-dev/epic-stack/blob/main/docs/getting-started.md) for the first time. This is because database was not seeded during setup. This change adds the command to the [Getting started docs](https://github.com/epicweb-dev/epic-stack/blob/main/docs/getting-started.md) that needs to be executed to seed the database. Additional context: https://discord.com/channels/715220730605731931/1420934400685899906/1420934400685899906.

## Test Plan

None

## Checklist

- [ ] Tests updated
- [x] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
