### PR TITLE
prevent assets fall through

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -84,7 +84,7 @@ if (viteDevServer) {
 	// Remix fingerprints its assets so we can cache forever.
 	app.use(
 		'/assets',
-		express.static('build/client/assets', { immutable: true, maxAge: '1y' }),
+		express.static('build/client/assets', { immutable: true, maxAge: '1y', fallthrough: false }),
 	)
 
 	// Everything else (like favicon.ico) is cached for an hour. You may want to be


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
Currently, requests to /assets/* that don’t match an existing asset fall through to the Remix handler. 
I think we can assume that these requests are always for assets and never for pages, so it’s safe to respond with 404 directly.

This avoids unnecessary page routing and can significantly reduce overhead in rare cases.
For example, when opening DevTools on a production site, the browser automatically requests all sourcemap files, which don’t exist in production. Without this change, each of these requests triggers the root loader, including all authentication logic and database access.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
