### PR TITLE
Fix note image duplication on navigate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules
 .DS_store
 
+mise.toml
+
 /build
 /server-build
 .env

--- a/app/routes/users+/$username_+/notes.$noteId.tsx
+++ b/app/routes/users+/$username_+/notes.$noteId.tsx
@@ -32,6 +32,7 @@ export async function loader({ params }: Route.LoaderArgs) {
 			updatedAt: true,
 			images: {
 				select: {
+					id: true,
 					altText: true,
 					objectKey: true,
 				},
@@ -123,7 +124,7 @@ export default function NoteRoute({
 			<div className={`${displayBar ? 'pb-24' : 'pb-12'} overflow-y-auto`}>
 				<ul className="flex flex-wrap gap-5 py-5">
 					{loaderData.note.images.map((image) => (
-						<li key={image.objectKey}>
+						<li key={image.id}>
 							<a href={getNoteImgSrc(image.objectKey)}>
 								<Img
 									src={getNoteImgSrc(image.objectKey)}

--- a/app/utils/cache.server.ts
+++ b/app/utils/cache.server.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
 import {
 	cachified as baseCachified,
 	verboseReporter,
@@ -13,7 +14,6 @@ import {
 } from '@epic-web/cachified'
 import { remember } from '@epic-web/remember'
 import { LRUCache } from 'lru-cache'
-import { DatabaseSync } from 'node:sqlite'
 import { z } from 'zod'
 import { updatePrimaryCacheValue } from '#app/routes/admin+/cache_.sqlite.server.ts'
 import { getInstanceInfo, getInstanceInfoSync } from './litefs.server.ts'

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -54,19 +54,21 @@ async function seed() {
 
 			// Add images to note
 			const noteImageCount = faker.number.int({ min: 1, max: 3 })
-			for (let imageIndex = 0; imageIndex < noteImageCount; imageIndex++) {
-				const imgNumber = faker.number.int({ min: 0, max: 9 })
-				const noteImage = noteImages[imgNumber]
-				if (noteImage) {
-					await prisma.noteImage.create({
+			const selectedImages = faker.helpers.arrayElements(
+				noteImages,
+				noteImageCount,
+			)
+			await Promise.all(
+				selectedImages.map((noteImage) =>
+					prisma.noteImage.create({
 						data: {
 							noteId: note.id,
 							altText: noteImage.altText,
 							objectKey: noteImage.objectKey,
 						},
-					})
-				}
-			}
+					}),
+				),
+			)
 		}
 	}
 	console.timeEnd(`👤 Created ${totalUsers} users...`)

--- a/tests/e2e/passkey.test.ts
+++ b/tests/e2e/passkey.test.ts
@@ -24,7 +24,7 @@ test('Users can register and use passkeys', async ({
 	navigate,
 	login,
 }) => {
-	const user = await login()
+	await login()
 
 	const { client, authenticatorId } = await setupWebAuthn(page)
 


### PR DESCRIPTION
This merge request fixes an issue where images were being duplicated when navigating indefinitely. This _I think_ is down to how React reconciles elements that do not have unique keys.

The fix is to use the note image id for the map keys so that the uniqueness required, exists. I have also added additional code to ensure that when seeding the database, a note is not created using the same image multiple times. The second bit might be beyond the scope of this so I am happy to remove it, I've included it as a nice to have (in my opinion).

Tests have not been updated but no functionality has been lost although  I don't believe this area of the code is currently covered.

## Test Plan

A bit of a tedious one to test because a new project is needed with a seeded database where a note is created with the same image being used multiple times. Once you have this, you will be able to navigate back and forth and see the issue as shown in #1046

Pulling down my changes, you will see that this issue is no longer happening as we have swapped out using the objectKey for the map key in favour of the image id.

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

Before:

https://github.com/user-attachments/assets/89683886-f56c-45f8-9a54-86853623b248

After:

https://github.com/user-attachments/assets/202144ca-dd27-4566-9fdd-503cf6251d92
