### PR TITLE
Set inputmode="text" by default to otpInput field

### DIFF
--- a/app/components/ui/input-otp.tsx
+++ b/app/components/ui/input-otp.tsx
@@ -9,7 +9,7 @@ const InputOTP = ({
 	...props
 }: React.ComponentProps<typeof OTPInput>) => (
 	<OTPInput
-		inputMode='text'
+		inputMode="text"
 		data-slot="input-otp"
 		containerClassName={cn(
 			'flex items-center gap-2 has-disabled:opacity-50',


### PR DESCRIPTION
On mobile device (onePlus 9 - Running chrome)
The keyboard provided during OTP is numeric only.
But the Otp can contain alphanumeric caracters

Solution: default html attr  inputmode to "text" on the Otp input

 ## Before
![before](https://github.com/user-attachments/assets/5398bf88-243d-4dba-bfdd-9373954b408c)

## After
![after](https://github.com/user-attachments/assets/e0ee78bd-e8c7-4fff-bd69-8019b22c61e8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set OTP input’s default `inputMode` to `text` to support alphanumeric entry (improves mobile keyboard behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1f2bfcb64f17ae71e482926e5b6455c94078794. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->