### PR TITLE
Update Prisma command to specific version 6

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,7 +48,7 @@ set SKIP_SETUP=true && set SKIP_FORMAT=true && set SKIP_DEPLOYMENT=true && npx e
 - Seed database:
 
   ```sh
-  npx prisma db seed
+  npx prisma@6 db seed
   ```
 
 - Start dev server:


### PR DESCRIPTION
Since npx points to the latest version of prisma which v7 which has breaking changes and this seed command fails  so pinning the npx version to 6 until we migrate the project to v7


## Test Plan

n/a

## Checklist

n/a

## Screenshots

n/a
