### PR TITLE
chore: change prisma generate command to use npm exec

### DIFF
--- a/other/Dockerfile
+++ b/other/Dockerfile
@@ -42,7 +42,7 @@ WORKDIR /myapp
 COPY --from=deps /myapp/node_modules /myapp/node_modules
 
 ADD prisma .
-RUN npx prisma generate
+RUN npm exec prisma generate
 
 ADD . .
 


### PR DESCRIPTION
This change replaces usages of npx with npm exec inside the Dockerfile to align with modern npm best practices and improve build determinism, security, and predictability.

## Motivation

npx may implicitly download and execute the latest version of a CLI at build time, which can introduce breaking changes without warning. This recently surfaced when Prisma released v7 of its CLI, causing unexpected breakage in an existing project.

Using npm exec ensures that only explicitly installed and lockfile-pinned dependencies are executed during the Docker build, reducing the risk of supply-chain surprises and improving reproducibility in CI environments.

