### PR TITLE
fix: filter Epic Stack Sentry healthcheck and bot noise

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -15,6 +15,7 @@ import {
 import { getEnv, init } from './utils/env.server.ts'
 import { getInstanceInfo } from './utils/litefs.server.ts'
 import { NonceProvider } from './utils/nonce-provider.ts'
+import { isExpectedReactRouterErrorMessage } from './utils/sentry-event-filters.ts'
 import { makeTimings } from './utils/timing.server.ts'
 
 export const streamTimeout = 5000
@@ -129,6 +130,15 @@ export function handleError(
 	// Skip capturing if the request is aborted as Remix docs suggest
 	// Ref: https://remix.run/docs/en/main/file-conventions/entry.server#handleerror
 	if (request.signal.aborted) {
+		return
+	}
+
+	// Expected React Router responses to unsupported methods / missing handlers
+	// (common from bots and scanners on the public demo). Don't alert.
+	if (
+		error instanceof Error &&
+		isExpectedReactRouterErrorMessage(error.message)
+	) {
 		return
 	}
 

--- a/app/routes/resources/healthcheck.tsx
+++ b/app/routes/resources/healthcheck.tsx
@@ -9,8 +9,10 @@ export async function loader({ request }: Route.LoaderArgs) {
 	try {
 		// if we can connect to the database and make a simple query
 		// and make a HEAD request to ourselves, then we're good.
+		// Prefer SELECT 1 over User.count(): count() was producing Slow DB Query
+		// Sentry insights on the tiny Fly demo VM without indicating app issues.
 		await Promise.all([
-			prisma.user.count(),
+			prisma.$queryRaw`SELECT 1`,
 			fetch(`${new URL(request.url).protocol}${host}`, {
 				method: 'HEAD',
 				headers: { 'X-Healthcheck': 'true' },

--- a/app/utils/sentry-event-filters.test.ts
+++ b/app/utils/sentry-event-filters.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from 'vitest'
+import {
+	isExpectedReactRouterErrorMessage,
+	isHealthcheckTransaction,
+	shouldDropErrorEvent,
+} from './sentry-event-filters.ts'
+
+test('detects missing action / loader / invalid method router errors', () => {
+	expect(
+		isExpectedReactRouterErrorMessage(
+			'You made a POST request to "/" but did not provide an `action` for route "root", so there is no way to handle the request.',
+		),
+	).toBe(true)
+	expect(
+		isExpectedReactRouterErrorMessage(
+			'You made a GET request to "/resources/theme-switch" but did not provide a `loader` for route "routes/resources/theme-switch", so there is no way to handle the request.',
+		),
+	).toBe(true)
+	expect(
+		isExpectedReactRouterErrorMessage('Invalid request method "OPTIONS"'),
+	).toBe(true)
+	expect(isExpectedReactRouterErrorMessage('Database connection failed')).toBe(
+		false,
+	)
+})
+
+test('shouldDropErrorEvent reads exception values', () => {
+	expect(
+		shouldDropErrorEvent({
+			exception: {
+				values: [
+					{
+						value:
+							'You made a POST request to "/" but did not provide an `action` for route "root", so there is no way to handle the request.',
+					},
+				],
+			},
+		}),
+	).toBe(true)
+	expect(
+		shouldDropErrorEvent({
+			exception: { values: [{ value: 'Unexpected server failure' }] },
+		}),
+	).toBe(false)
+})
+
+test('isHealthcheckTransaction matches url, header, and orphaned prisma dsc', () => {
+	expect(
+		isHealthcheckTransaction({
+			request: { url: 'http://127.0.0.1:8080/resources/healthcheck' },
+		}),
+	).toBe(true)
+	expect(
+		isHealthcheckTransaction({
+			request: { headers: { 'x-healthcheck': 'true' } },
+		}),
+	).toBe(true)
+	expect(
+		isHealthcheckTransaction({
+			transaction: 'prisma:client:operation',
+			tags: { url: 'http://172.19.14.2:8080/resources/healthcheck' },
+			contexts: {
+				trace: {
+					data: {
+						'sentry.dsc.transaction': 'GET /resources/healthcheck',
+					},
+				},
+			},
+		}),
+	).toBe(true)
+	expect(
+		isHealthcheckTransaction({
+			transaction: 'GET /users',
+			request: { url: 'https://example.com/users' },
+		}),
+	).toBe(false)
+})

--- a/app/utils/sentry-event-filters.ts
+++ b/app/utils/sentry-event-filters.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure helpers for dropping expected Sentry noise from the public Epic Stack
+ * demo (bots, scanners, Fly healthchecks) without hiding real application bugs.
+ */
+
+const EXPECTED_REACT_ROUTER_ERROR_PATTERNS = [
+	/did not provide an `action`/i,
+	/did not provide a `loader`/i,
+	/^Invalid request method /i,
+]
+
+export function isExpectedReactRouterErrorMessage(message: string): boolean {
+	return EXPECTED_REACT_ROUTER_ERROR_PATTERNS.some((pattern) =>
+		pattern.test(message),
+	)
+}
+
+export function getEventErrorMessages(event: {
+	message?: string
+	exception?: { values?: Array<{ value?: string | null } | null> | null }
+}): string[] {
+	const messages: string[] = []
+	for (const value of event.exception?.values ?? []) {
+		if (value?.value) messages.push(value.value)
+	}
+	if (event.message) messages.push(event.message)
+	return messages
+}
+
+export function shouldDropErrorEvent(event: {
+	message?: string
+	exception?: { values?: Array<{ value?: string | null } | null> | null }
+}): boolean {
+	return getEventErrorMessages(event).some(isExpectedReactRouterErrorMessage)
+}
+
+type TransactionLike = {
+	transaction?: string | null
+	request?: {
+		url?: string | null
+		headers?: Record<string, string> | null
+	} | null
+	tags?: Record<string, unknown> | null
+	contexts?: {
+		trace?: {
+			data?: Record<string, unknown> | null
+		} | null
+	} | null
+}
+
+function includesHealthcheckPath(value: string): boolean {
+	return value.includes('/resources/healthcheck')
+}
+
+export function isHealthcheckTransaction(event: TransactionLike): boolean {
+	if (event.request?.headers?.['x-healthcheck'] === 'true') {
+		return true
+	}
+
+	const candidates = [
+		event.request?.url,
+		event.transaction,
+		typeof event.tags?.url === 'string' ? event.tags.url : null,
+		typeof event.contexts?.trace?.data?.['sentry.dsc.transaction'] === 'string'
+			? event.contexts.trace.data['sentry.dsc.transaction']
+			: null,
+	]
+
+	return candidates.some(
+		(value) => typeof value === 'string' && includesHealthcheckPath(value),
+	)
+}

--- a/docs/skills/epic-deployment/SKILL.md
+++ b/docs/skills/epic-deployment/SKILL.md
@@ -122,7 +122,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
 	try {
 		await Promise.all([
-			prisma.user.count(), // Verify DB
+			prisma.$queryRaw`SELECT 1`, // Verify DB
 			fetch(`${new URL(request.url).protocol}${host}`, {
 				method: 'HEAD',
 				headers: { 'X-Healthcheck': 'true' },

--- a/docs/skills/epic-routing/SKILL.md
+++ b/docs/skills/epic-routing/SKILL.md
@@ -207,7 +207,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
 	try {
 		await Promise.all([
-			prisma.user.count(), // Check DB
+			prisma.$queryRaw`SELECT 1`, // Check DB
 			fetch(`${new URL(request.url).protocol}${host}`, {
 				method: 'HEAD',
 				headers: { 'X-Healthcheck': 'true' },

--- a/server/utils/monitoring.ts
+++ b/server/utils/monitoring.ts
@@ -1,6 +1,10 @@
 import { PrismaInstrumentation } from '@prisma/instrumentation'
 import { nodeProfilingIntegration } from '@sentry/profiling-node'
 import * as Sentry from '@sentry/react-router'
+import {
+	isHealthcheckTransaction,
+	shouldDropErrorEvent,
+} from '../../app/utils/sentry-event-filters.ts'
 
 export function init() {
 	Sentry.init({
@@ -16,6 +20,12 @@ export function init() {
 			/\/favicon.ico/,
 			/\/site\.webmanifest/,
 		],
+		ignoreErrors: [
+			// Bots/scanners hitting routes without the matching loader/action/method.
+			/did not provide an `action`/,
+			/did not provide a `loader`/,
+			/^Invalid request method /,
+		],
 		integrations: [
 			Sentry.prismaIntegration({
 				prismaInstrumentation: new PrismaInstrumentation(),
@@ -30,10 +40,16 @@ export function init() {
 			}
 			return process.env.NODE_ENV === 'production' ? 1 : 0
 		},
+		beforeSend(event) {
+			if (shouldDropErrorEvent(event)) {
+				return null
+			}
+			return event
+		},
 		beforeSendTransaction(event) {
-			// ignore all healthcheck related transactions
-			//  note that name of header here is case-sensitive
-			if (event.request?.headers?.['x-healthcheck'] === 'true') {
+			// Drop Fly/consul healthchecks, including orphaned Prisma spans that
+			// surface as Slow DB Query insights with transaction prisma:client:operation.
+			if (isHealthcheckTransaction(event)) {
 				return null
 			}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry project `epic-stack` was dominated by non-actionable noise on the public template demo:

1. **Slow DB Query** (`EPIC-STACK-2A`) — Fly healthchecks calling `prisma.user.count()`. Orphaned Prisma spans still reached Sentry as `prisma:client:operation`.
2. **`getInternalRouterError` family** (`EPIC-STACK-22` / `28` / `21`) — bots/scanners hitting `POST /` without an action, `GET /resources/theme-switch` without a loader, and `OPTIONS /`.
3. **`TypeError: Load failed`** (`EPIC-STACK-2B`) — one-off Mobile Safari network blip; ignore in Sentry (no code change).

### Changes
- Healthcheck DB probe: `prisma.user.count()` → `prisma.$queryRaw\`SELECT 1\``
- Server Sentry filters for expected React Router method/handler errors and orphaned healthcheck Prisma transactions
- `handleError` skips capturing those expected router errors
- Unit tests for the pure filter helpers

### Risk
**Low** — monitoring/filter + lighter healthcheck query only.

## Test Plan

- [x] `vitest run app/utils/sentry-event-filters.test.ts`
- [x] `npm run lint` / `npm run typecheck`
- [ ] CI green on this PR

## Checklist

- [x] Tests updated
- [x] Docs updated

## Screenshots

N/A (Sentry/monitoring + healthcheck probe only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84e15881-1651-452c-9a99-9369238dd5e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84e15881-1651-452c-9a99-9369238dd5e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

