### PR TITLE
fix: stop Sentry double debug IDs breaking client source maps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,7 +43,9 @@ export default defineConfig((config) => {
 			}
 		},
 
-		sourcemap: true,
+		// 'hidden' emits maps for Sentry upload but omits //# sourceMappingURL=
+		// so public /assets never advertise map URLs (esp. when auth token is unset)
+		sourcemap: 'hidden',
 	},
 	server: {
 		watch: {
@@ -84,20 +86,20 @@ export default defineConfig((config) => {
 	}
 })
 
+// Keep release on the supported top-level fields. Do not pass `sourcemaps`
+// through `unstable_sentryVitePluginOptions` — that overwrites the plugin's
+// `sourcemaps.disable: true` and injects a second debug ID per chunk
+// (getsentry/sentry-javascript#22929). sentryOnBuildEnd deletes maps via its
+// default `${buildDirectory}/**/*.map` glob.
 const sentryConfig: SentryReactRouterBuildOptions = {
 	authToken: process.env.SENTRY_AUTH_TOKEN,
 	org: process.env.SENTRY_ORG,
 	project: process.env.SENTRY_PROJECT,
 
-	unstable_sentryVitePluginOptions: {
-		release: {
-			name: process.env.COMMIT_SHA,
-			setCommits: {
-				auto: true,
-			},
-		},
-		sourcemaps: {
-			filesToDeleteAfterUpload: ['./build/**/*.map'],
+	release: {
+		name: process.env.COMMIT_SHA,
+		setCommits: {
+			auto: true,
 		},
 	},
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1094.

Passing `sourcemaps` through `unstable_sentryVitePluginOptions` overwrites `@sentry/react-router`'s intentional `sourcemaps.disable: true`. That re-enables Vite-plugin debug ID injection on top of `sentryOnBuildEnd`, so every client chunk ships two debug IDs — and the one that wins at runtime has no uploaded map (`js_no_source`). Upstream: getsentry/sentry-javascript#22929.

## Changes

- Move `release` (`name` + `setCommits`) to the supported top-level `SentryReactRouterBuildOptions` fields
- Drop `unstable_sentryVitePluginOptions` entirely — `sentryOnBuildEnd` already deletes maps via `` `${buildDirectory}/**/*.map` ``
- Set `build.sourcemap: 'hidden'` so maps are still emitted for upload without a public `sourceMappingURL` comment

## Test plan

- [ ] Confirm `vite.config.ts` typechecks with the top-level `release` shape
- [ ] Production build with `SENTRY_AUTH_TOKEN` set: each client chunk should contain a single debug ID
- [ ] Confirm uploaded artifacts match that debug ID and client frames symbolicate in Sentry
- [ ] Confirm shipped client assets have no `//# sourceMappingURL=` comment
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad9288c4-caf6-42fa-af5c-bd2971f99017?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad9288c4-caf6-42fa-af5c-bd2971f99017&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

