### PR TITLE
Add Mailtrap Local example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -123,6 +123,10 @@ This page links to examples of how to implement some things with the Epic Stack.
   [@dmno-dev](https://github.com/dmno-dev): Using [Varlock](https://varlock.dev)
   and a `.env.schema` file to to improve DX and security of configuration and
   secrets.
+- [Mailtrap Local](https://github.com/tsokolovs/epic-stack-with-mailtrap-local)
+  by [@tsokolovs](https://github.com/tsokolovs): Sending mail through a local
+  SMTP server in development, so the emails the app sends can be opened and read
+  in a browser instead of the terminal.
 
 ## How to contribute
 


### PR DESCRIPTION
<!-- Summary: Put your summary here -->

Adds a [Mailtrap Local example repo](https://github.com/tsokolovs/epic-stack-with-mailtrap-local) to the examples page. It sends mail through a local SMTP server in development so the emails the app sends can be read in a browser instead of the terminal.

See that repo's README for more details.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

Docs-only change here — the entry is one bullet on the examples page.

For the linked example: `docker compose up -d`, `npm run dev`, sign up, and the welcome email shows up at http://127.0.0.1:3550. `npm run validate` passes — the existing e2e tests still read emails from the MSW mock's fixtures, and there's an added test covering the SMTP path that skips itself when the container isn't running.

## Checklist

- [ ] Tests updated
- [x] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->

N/A — docs only. There's a screenshot of the caught email in the example's README.
